### PR TITLE
fix: Complete sentinel-agent -> arktis-agent rebrand and add go.sum

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
         include:
           - goos: linux
             goarch: amd64
-            binary: sentinel-agent-linux-amd64
+            binary: arktis-agent-linux-amd64
           - goos: linux
             goarch: arm64
-            binary: sentinel-agent-linux-arm64
+            binary: arktis-agent-linux-arm64
           - goos: windows
             goarch: amd64
-            binary: sentinel-agent-windows-amd64.exe
+            binary: arktis-agent-windows-amd64.exe
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           go build -ldflags "-X main.Version=${VERSION} -s -w" \
-            -o ${{ matrix.binary }} ./cmd/sentinel-agent
+            -o ${{ matrix.binary }} ./cmd/arktis-agent
 
       - uses: actions/upload-artifact@v4
         with:
@@ -58,6 +58,6 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            sentinel-agent-linux-amd64
-            sentinel-agent-linux-arm64
-            sentinel-agent-windows-amd64.exe
+            arktis-agent-linux-amd64
+            arktis-agent-linux-arm64
+            arktis-agent-windows-amd64.exe

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ DIST := dist
 build-all: build-linux-amd64 build-linux-arm64 build-windows-amd64
 
 build-linux-amd64:
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(DIST)/sentinel-agent-linux-amd64 ./cmd/sentinel-agent
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(DIST)/arktis-agent-linux-amd64 ./cmd/arktis-agent
 
 build-linux-arm64:
-	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o $(DIST)/sentinel-agent-linux-arm64 ./cmd/sentinel-agent
+	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o $(DIST)/arktis-agent-linux-arm64 ./cmd/arktis-agent
 
 build-windows-amd64:
-	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(DIST)/sentinel-agent-windows-amd64.exe ./cmd/sentinel-agent
+	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(DIST)/arktis-agent-windows-amd64.exe ./cmd/arktis-agent
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Sentinel Agent
+# Arktis Agent
 
-Lightweight reverse-connection agent for [Sentinel Review](https://github.com/bisskar/app-sentinel-review). Connects lab hosts back to the Sentinel Review backend via WebSocket for remote Atomic Red Team test execution, interactive terminal sessions, and AI-powered analysis.
+Lightweight reverse-connection agent for [Arktis](https://github.com/bisskar/arktis). Connects lab hosts back to the Arktis backend via WebSocket for remote Atomic Red Team test execution, interactive terminal sessions, and AI-powered analysis.
 
 Single binary. Zero dependencies on target.
 
@@ -8,35 +8,35 @@ Single binary. Zero dependencies on target.
 
 ```
 Traditional:  Backend --SSH--> Lab Host    (requires inbound firewall rules)
-Sentinel Agent:  Backend <--WS-- Agent    (outbound only, NAT-friendly)
+Arktis Agent: Backend <--WS-- Agent        (outbound only, NAT-friendly)
 ```
 
-The agent runs on your lab hosts (Windows or Linux) and maintains a persistent WebSocket connection to the Sentinel Review backend. The backend sends commands through this connection — no inbound ports, no SSH keys, no firewall rules needed on the target.
+The agent runs on your lab hosts (Windows or Linux) and maintains a persistent WebSocket connection to the Arktis backend. The backend sends commands through this connection — no inbound ports, no SSH keys, no firewall rules needed on the target.
 
 ## Quick Start
 
 ### 1. Generate a Registration Key
 
-In Sentinel Review, go to **Org Settings > Lab Hosts > Registration Keys** and click **Generate Key**. Select the workspace to scope the key to (or leave blank for org-wide).
+In Arktis, go to **Org Settings > Lab Hosts > Registration Keys** and click **Generate Key**. Select the workspace to scope the key to (or leave blank for org-wide).
 
 ### 2. Install the Agent
 
 **Linux:**
 
 ```bash
-curl -sSL https://github.com/bisskar/sentinel-agent/releases/latest/download/sentinel-agent-linux-amd64 \
-  -o /usr/local/bin/sentinel-agent && chmod +x /usr/local/bin/sentinel-agent
+curl -sSL https://github.com/bisskar/arktis-agent/releases/latest/download/arktis-agent-linux-amd64 \
+  -o /usr/local/bin/arktis-agent && chmod +x /usr/local/bin/arktis-agent
 
-sentinel-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
+arktis-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://github.com/bisskar/sentinel-agent/releases/latest/download/sentinel-agent-windows-amd64.exe" `
-  -OutFile "$env:ProgramFiles\sentinel-agent.exe"
+Invoke-WebRequest -Uri "https://github.com/bisskar/arktis-agent/releases/latest/download/arktis-agent-windows-amd64.exe" `
+  -OutFile "$env:ProgramFiles\arktis-agent.exe"
 
-& "$env:ProgramFiles\sentinel-agent.exe" --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
+& "$env:ProgramFiles\arktis-agent.exe" --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
 ```
 
 The agent self-registers on first connect. It will appear in your Lab Hosts list within seconds.
@@ -46,14 +46,14 @@ The agent self-registers on first connect. It will appear in your Lab Hosts list
 **Linux (systemd):**
 
 ```bash
-sudo tee /etc/systemd/system/sentinel-agent.service > /dev/null <<EOF
+sudo tee /etc/systemd/system/arktis-agent.service > /dev/null <<EOF
 [Unit]
-Description=Sentinel Agent
+Description=Arktis Agent
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/sentinel-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
+ExecStart=/usr/local/bin/arktis-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
 Restart=always
 RestartSec=5
 User=root
@@ -63,17 +63,17 @@ WantedBy=multi-user.target
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable --now sentinel-agent
+sudo systemctl enable --now arktis-agent
 ```
 
 **Windows (as a scheduled task):**
 
 ```powershell
-$action = New-ScheduledTaskAction -Execute "$env:ProgramFiles\sentinel-agent.exe" `
+$action = New-ScheduledTaskAction -Execute "$env:ProgramFiles\arktis-agent.exe" `
   -Argument "--url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>"
 $trigger = New-ScheduledTaskTrigger -AtStartup
 $settings = New-ScheduledTaskSettingsSet -RestartCount 999 -RestartInterval (New-TimeSpan -Seconds 30)
-Register-ScheduledTask -TaskName "SentinelAgent" -Action $action -Trigger $trigger `
+Register-ScheduledTask -TaskName "ArktisAgent" -Action $action -Trigger $trigger `
   -Settings $settings -User "SYSTEM" -RunLevel Highest
 ```
 
@@ -93,31 +93,31 @@ Register-ScheduledTask -TaskName "SentinelAgent" -Action $action -Trigger $trigg
 
 ```
 ┌──────────────┐     WebSocket (outbound)     ┌──────────────────┐
-│  Lab Host    │ ──────────────────────────>   │  Sentinel Review │
-│              │                               │  Backend         │
-│  sentinel-   │  <── exec commands            │                  │
-│  agent       │  ──> exec results             │  AgentConnection │
-│              │  <── pty_open/input/resize     │  Manager         │
-│              │  ──> pty_output                │                  │
-│              │  <── heartbeat_ack             │                  │
-│              │  ──> heartbeat (15s)           │                  │
-└──────────────┘                               └──────────────────┘
+│  Lab Host    │ ──────────────────────────>  │  Arktis Backend  │
+│              │                              │                  │
+│  arktis-     │  <── exec commands           │                  │
+│  agent       │  ──> exec results            │  AgentConnection │
+│              │  <── pty_open/input/resize   │  Manager         │
+│              │  ──> pty_output              │                  │
+│              │  <── heartbeat_ack           │                  │
+│              │  ──> heartbeat (15s)         │                  │
+└──────────────┘                              └──────────────────┘
 ```
 
 ## Configuration
 
 | Flag | Environment Variable | Default | Description |
 |------|---------------------|---------|-------------|
-| `--url` | `SENTINEL_URL` | (required) | Backend WebSocket URL |
-| `--key` | `SENTINEL_KEY` | (required) | Registration key from Sentinel Review |
-| `--state-dir` | `SENTINEL_STATE_DIR` | `/etc/sentinel-agent` (Linux) or `%ProgramData%\sentinel-agent` (Windows) | Directory for persistent state |
+| `--url` | `ARKTIS_URL` | (required) | Backend WebSocket URL |
+| `--key` | `ARKTIS_KEY` | (required) | Registration key from Arktis |
+| `--state-dir` | `ARKTIS_STATE_DIR` | `/etc/arktis-agent` (Linux) or `%ProgramData%\arktis-agent` (Windows) | Directory for persistent state |
 | `--version` | — | — | Print version and exit |
 
 ## Security
 
 - **Outbound only** — the agent initiates the connection. No inbound ports needed on the target host.
 - **Key-based authentication** — agents authenticate with a registration key (SHA-256 hashed server-side, never stored in plaintext).
-- **Key revocation** — revoking a key in Sentinel Review immediately disconnects all agents using it.
+- **Key revocation** — revoking a key in Arktis immediately disconnects all agents using it.
 - **Per-agent revocation** — individual hosts can be deactivated without affecting other agents on the same key.
 - **TLS transport** — use `wss://` in production for encrypted communication.
 - **Org/workspace scoping** — each key is bound to one organization and optionally one workspace. Agents cannot execute commands for other tenants.
@@ -143,7 +143,7 @@ ls dist/
 
 ```bash
 # Run locally
-go run ./cmd/sentinel-agent --url ws://localhost:8000/api/v1/agent/ws --key <KEY>
+go run ./cmd/arktis-agent --url ws://localhost:8000/api/v1/agent/ws --key <KEY>
 
 # Run tests
 make test
@@ -151,4 +151,4 @@ make test
 
 ## License
 
-Private. Part of the Sentinel Review platform.
+Private. Part of the Arktis platform.

--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -10,9 +10,9 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/bisskar/sentinel-agent/internal/config"
-	"github.com/bisskar/sentinel-agent/internal/connection"
-	"github.com/bisskar/sentinel-agent/internal/session"
+	"github.com/bisskar/arktis-agent/internal/config"
+	"github.com/bisskar/arktis-agent/internal/connection"
+	"github.com/bisskar/arktis-agent/internal/session"
 )
 
 // Version is set via ldflags at build time.
@@ -24,9 +24,9 @@ func defaultStateDir() string {
 		if pd == "" {
 			pd = `C:\ProgramData`
 		}
-		return pd + `\sentinel-agent`
+		return pd + `\arktis-agent`
 	}
-	return "/etc/sentinel-agent"
+	return "/etc/arktis-agent"
 }
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("sentinel-agent %s\n", Version)
+		fmt.Printf("arktis-agent %s\n", Version)
 		os.Exit(0)
 	}
 
@@ -65,7 +65,7 @@ func main() {
 		state = &config.State{}
 	}
 
-	log.Printf("sentinel-agent %s starting (state-dir=%s)", Version, cfg.StateDir)
+	log.Printf("arktis-agent %s starting (state-dir=%s)", Version, cfg.StateDir)
 
 	// Inject version into the connection package for registration messages.
 	connection.SetVersion(Version)
@@ -92,5 +92,5 @@ func main() {
 		log.Fatalf("Agent exited with error: %v", err)
 	}
 
-	log.Println("sentinel-agent stopped")
+	log.Println("arktis-agent stopped")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bisskar/sentinel-agent
+module github.com/bisskar/arktis-agent
 
 go 1.22
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bisskar/sentinel-agent/internal/config"
-	"github.com/bisskar/sentinel-agent/internal/executor"
-	"github.com/bisskar/sentinel-agent/internal/session"
+	"github.com/bisskar/arktis-agent/internal/config"
+	"github.com/bisskar/arktis-agent/internal/executor"
+	"github.com/bisskar/arktis-agent/internal/session"
 	"github.com/gorilla/websocket"
 )
 

--- a/internal/executor/command.go
+++ b/internal/executor/command.go
@@ -130,7 +130,7 @@ func buildCmdPromptCmd(ctx context.Context, command string) (*exec.Cmd, error) {
 	// cmd.exe runs the file directly, so the commands are visible in
 	// process creation events and file system monitoring.
 	tmpDir := os.TempDir()
-	tmpFile := filepath.Join(tmpDir, fmt.Sprintf("sentinel_%d.bat", time.Now().UnixNano()))
+	tmpFile := filepath.Join(tmpDir, fmt.Sprintf("arktis_%d.bat", time.Now().UnixNano()))
 
 	// Ensure CRLF line endings for Windows batch files, append self-cleanup
 	script := strings.ReplaceAll(command, "\n", "\r\n")
@@ -151,7 +151,7 @@ func buildCmdPromptCmd(ctx context.Context, command string) (*exec.Cmd, error) {
 // parsing. A temp file avoids all escaping issues.
 //
 // Detection visibility:
-//   - Process tree shows: /bin/bash /tmp/sentinel_xxx.sh
+//   - Process tree shows: /bin/bash /tmp/arktis_xxx.sh
 //   - Each command inside the script spawns child processes with
 //     their full command lines visible to auditd/sysmon
 //   - File integrity monitoring can read the script content
@@ -168,7 +168,7 @@ func buildShCmd(ctx context.Context, command string, elevationRequired bool) *ex
 // buildShellScript writes a command to a temp script and returns a Cmd to run it.
 // The script is self-deleting (trap on EXIT removes the temp file).
 func buildShellScript(ctx context.Context, command string, shell string, elevationRequired bool) *exec.Cmd {
-	tmpFile := filepath.Join(os.TempDir(), fmt.Sprintf("sentinel_%d.sh", time.Now().UnixNano()))
+	tmpFile := filepath.Join(os.TempDir(), fmt.Sprintf("arktis_%d.sh", time.Now().UnixNano()))
 
 	// Prepend a self-cleanup trap and a shebang
 	script := fmt.Sprintf("#!%s\ntrap 'rm -f \"%s\"' EXIT\n%s\n", shell, tmpFile, command)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/bisskar/sentinel-agent/internal/executor"
+	"github.com/bisskar/arktis-agent/internal/executor"
 )
 
 // Sender is the interface for sending messages back to the backend.


### PR DESCRIPTION
## Summary

- Finalize the rename of the agent repository from `sentinel-agent` to `arktis-agent`
- Fix CI build failure caused by a missing `go.sum` file
- Update all branding in README, Makefile, release workflow, and source code

## Root cause of CI failure

The repo never had a `go.sum` committed, so CI builds failed with:
```
internal/executor/shell_linux.go:13:2: missing go.sum entry for module providing package github.com/creack/pty
internal/connection/websocket.go:16:2: missing go.sum entry for module providing package github.com/gorilla/websocket
```

`.gitignore` does not exclude `go.sum`; it simply was never generated and committed after `go mod init`.

## Changes

| File | Change |
|---|---|
| `cmd/sentinel-agent/main.go` -> `cmd/arktis-agent/main.go` | Rename and update log/flag strings |
| `go.mod` | Module path: `github.com/bisskar/sentinel-agent` -> `github.com/bisskar/arktis-agent` |
| `go.sum` | **New file** — checksums for `gorilla/websocket v1.5.3` and `creack/pty v1.1.21` |
| `internal/connection/websocket.go` | Import path update |
| `internal/executor/command.go` | Import path update + temp file prefix `sentinel_` -> `arktis_` |
| `internal/session/manager.go` | Import path update |
| `Makefile` | Binary names and build target path |
| `.github/workflows/release.yml` | Binary names and build path |
| `README.md` | Full rebrand: install URLs, service names, config flag env vars (`SENTINEL_*` -> `ARKTIS_*`), state dirs (`/etc/arktis-agent`), systemd unit name |

## Verification

Built and vetted locally inside `docker run golang:1.22`:

```
go vet ./...                                               # pass
go build -buildvcs=false ./cmd/arktis-agent                # linux-amd64 pass
GOOS=windows GOARCH=amd64 go build ... ./cmd/arktis-agent  # windows-amd64 pass
```

No test files exist yet, so `make test` is trivially green.

## Test plan

- [x] CI `build-and-test` job passes on this PR
- [ ] On merge, a tagged release build produces `arktis-agent-{linux-amd64,linux-arm64,windows-amd64.exe}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)