### PR TITLE
fix: harden exec/PTY handling and registration ack

### DIFF
--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -150,8 +150,16 @@ func (c *Client) connect(ctx context.Context) error {
 		return fmt.Errorf("parse ack payload: %w", err)
 	}
 
-	// Persist host_id.
-	if ack.HostID != "" && ack.HostID != c.state.HostID {
+	// Persist host_id. The backend MUST return one — without it we have no
+	// stable identity for subsequent messages, so reject the ack and let
+	// the reconnect loop try again.
+	if ack.HostID == "" {
+		c.closeConn()
+		return fmt.Errorf("ack missing host_id")
+	}
+
+	switch {
+	case c.state.HostID == "":
 		c.state.HostID = ack.HostID
 		c.state.RegisteredAt = time.Now().UTC().Format(time.RFC3339)
 		if err := config.SaveState(c.config.StateDir, c.state); err != nil {
@@ -159,7 +167,17 @@ func (c *Client) connect(ctx context.Context) error {
 		} else {
 			log.Printf("Registered with host_id=%s", ack.HostID)
 		}
-	} else {
+	case ack.HostID != c.state.HostID:
+		// Backend reassigned us — surface this prominently so an operator
+		// can spot a rename / re-enrollment instead of silently rotating.
+		log.Printf("Warning: backend changed host_id from %s to %s; updating state",
+			c.state.HostID, ack.HostID)
+		c.state.HostID = ack.HostID
+		c.state.RegisteredAt = time.Now().UTC().Format(time.RFC3339)
+		if err := config.SaveState(c.config.StateDir, c.state); err != nil {
+			log.Printf("Warning: failed to save state: %v", err)
+		}
+	default:
 		log.Printf("Re-connected with host_id=%s", c.state.HostID)
 	}
 
@@ -224,7 +242,7 @@ func (c *Client) readLoop(ctx context.Context) {
 				log.Printf("Failed to parse exec message: %v", err)
 				continue
 			}
-			go c.manager.HandleExec(&msg, c)
+			go c.manager.HandleExec(ctx, &msg, c)
 
 		case "pty_open":
 			var msg session.PtyOpenMessage

--- a/internal/executor/command.go
+++ b/internal/executor/command.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const maxOutputBytes = 1 * 1024 * 1024 // 1 MB
@@ -185,5 +186,11 @@ func truncate(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
 		return s
 	}
-	return s[:maxBytes] + "\n[OUTPUT TRUNCATED at 1MB]"
+	// Back up to a UTF-8 rune boundary so we don't emit invalid UTF-8
+	// (which JSON encoding would later replace with U+FFFD).
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "\n[OUTPUT TRUNCATED at 1MB]"
 }

--- a/internal/executor/pty_size.go
+++ b/internal/executor/pty_size.go
@@ -1,0 +1,28 @@
+package executor
+
+// PTY winsize defaults used when a backend message omits or supplies
+// out-of-range dimensions. The upper bound is uint16's max (65535),
+// which is what the underlying TIOCSWINSZ / ConPty APIs accept.
+const (
+	defaultPtyCols = 80
+	defaultPtyRows = 24
+	maxPtyDim      = 65535
+)
+
+// sanitizePtySize clamps untrusted cols/rows from the backend into the
+// uint16 range expected by pty.Setsize / conpty.Resize. Non-positive
+// values fall back to sensible defaults so that an `int` -> `uint16`
+// conversion can never wrap to an enormous (or zero) terminal size.
+func sanitizePtySize(cols, rows int) (uint16, uint16) {
+	if cols <= 0 {
+		cols = defaultPtyCols
+	} else if cols > maxPtyDim {
+		cols = maxPtyDim
+	}
+	if rows <= 0 {
+		rows = defaultPtyRows
+	} else if rows > maxPtyDim {
+		rows = maxPtyDim
+	}
+	return uint16(cols), uint16(rows)
+}

--- a/internal/executor/shell_linux.go
+++ b/internal/executor/shell_linux.go
@@ -37,13 +37,8 @@ func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtyS
 		return nil, fmt.Errorf("start pty: %w", err)
 	}
 
-	// Set initial window size.
-	if cols > 0 && rows > 0 {
-		pty.Setsize(ptmx, &pty.Winsize{
-			Cols: uint16(cols),
-			Rows: uint16(rows),
-		})
-	}
+	colsU, rowsU := sanitizePtySize(cols, rows)
+	pty.Setsize(ptmx, &pty.Winsize{Cols: colsU, Rows: rowsU})
 
 	return &PtySession{
 		sessionID: sessionID,
@@ -60,10 +55,8 @@ func (p *PtySession) Write(data []byte) (int, error) {
 
 // Resize changes the PTY window size.
 func (p *PtySession) Resize(cols int, rows int) error {
-	return pty.Setsize(p.pty, &pty.Winsize{
-		Cols: uint16(cols),
-		Rows: uint16(rows),
-	})
+	colsU, rowsU := sanitizePtySize(cols, rows)
+	return pty.Setsize(p.pty, &pty.Winsize{Cols: colsU, Rows: rowsU})
 }
 
 // Close terminates the PTY session.

--- a/internal/executor/shell_windows.go
+++ b/internal/executor/shell_windows.go
@@ -32,15 +32,10 @@ type PtySession struct {
 func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtySession, error) {
 	shell := resolveWindowsShell()
 
-	if cols <= 0 {
-		cols = 80
-	}
-	if rows <= 0 {
-		rows = 24
-	}
+	colsU, rowsU := sanitizePtySize(cols, rows)
 
 	cpty, err := conpty.Start(shell,
-		conpty.ConPtyDimensions(cols, rows),
+		conpty.ConPtyDimensions(int(colsU), int(rowsU)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("start conpty with %q: %w", shell, err)
@@ -80,10 +75,8 @@ func (p *PtySession) Write(data []byte) (int, error) {
 
 // Resize changes the ConPTY window size.
 func (p *PtySession) Resize(cols int, rows int) error {
-	if cols <= 0 || rows <= 0 {
-		return nil
-	}
-	return p.cpty.Resize(cols, rows)
+	colsU, rowsU := sanitizePtySize(cols, rows)
+	return p.cpty.Resize(int(colsU), int(rowsU))
 }
 
 // Close terminates the ConPTY session.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -92,11 +92,15 @@ func NewManager() *Manager {
 // HandleExec executes the command directly (no encoding) and sends the result back.
 // Commands are run in plain text so detection rules can see them in process events.
 // Intended to be called in a goroutine.
-func (m *Manager) HandleExec(msg *ExecMessage, sender Sender) {
+//
+// ctx is the agent's root context — cancelling it (e.g. on SIGTERM) will
+// kill the child process so we don't block shutdown waiting for a long
+// command to finish.
+func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sender) {
 	log.Printf("Executing command (request_id=%s, executor=%s)", msg.RequestID, msg.ExecutorName)
 
 	stdout, stderr, exitCode, duration, err := executor.ExecuteCommand(
-		context.Background(),
+		ctx,
 		msg.Command,
 		msg.ExecutorName,
 		msg.ElevationRequired,


### PR DESCRIPTION
## Summary

Addresses four open issues with small, focused fixes:

- **#24** — `truncate()` now backs up to a UTF-8 rune boundary before cutting, so 1MB-truncated stdout/stderr stays valid UTF-8 (no more silent U+FFFD substitution by the JSON encoder).
- **#17** — New `sanitizePtySize` helper clamps cols/rows to `[1, 65535]` (defaults `80x24`) on both Linux and Windows for `NewPtySession` and `Resize`, eliminating the `int → uint16` wrap on negative or oversized input.
- **#32** — An ack with an empty `host_id` is now rejected (forces a reconnect) instead of silently accepted, and a backend-driven `host_id` change is logged as a warning rather than rotated silently.
- **#7** — `HandleExec` accepts the agent's root context and forwards it to `ExecuteCommand`, so SIGTERM kills any in-flight child process instead of waiting for the per-command timeout.

## Test plan

- [x] `go build ./...` clean on `linux`
- [x] `go vet ./...` clean on `linux`
- [x] `GOOS=windows go build ./...` clean
- [x] `GOOS=windows go vet ./...` clean
- [ ] Manual: send `pty_open` with `cols=-1, rows=0` and verify session opens at 80x24
- [ ] Manual: kill the agent mid-`exec` and verify the child process exits promptly
- [ ] Manual: backend ack with empty `host_id` triggers reconnect, not registration

https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz)_