### PR TITLE
fix: child-env whitelist, shell validation, state-load errors, x/sys bump

### DIFF
--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/signal"
@@ -68,11 +70,21 @@ func main() {
 		log.Fatalf("Failed to create scripts directory %s: %v", scriptsDir, err)
 	}
 
-	// Load or create persistent state.
+	// Load or create persistent state. Only the genuine "no file yet" case
+	// should silently fall through to a fresh registration; everything else
+	// (permission denied, corrupt JSON, failing disk) must abort startup
+	// rather than silently re-register and orphan the previous host record.
 	state, err := config.LoadState(cfg.StateDir)
-	if err != nil {
-		log.Printf("No existing state found, starting fresh: %v", err)
+	switch {
+	case err == nil:
+		// proceed with the loaded state
+	case errors.Is(err, fs.ErrNotExist):
+		log.Printf("First boot: no state.json in %s, starting fresh", cfg.StateDir)
 		state = &config.State{}
+	default:
+		log.Fatalf("Failed to load state from %s: %v "+
+			"(refusing to start; fix manually or delete state.json)",
+			cfg.StateDir, err)
 	}
 
 	log.Printf("arktis-agent %s starting (state-dir=%s)", Version, cfg.StateDir)

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/gorilla/websocket v1.5.3
 )
 
-require golang.org/x/sys v0.8.0 // indirect
+require golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,6 @@ github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/executor/command.go
+++ b/internal/executor/command.go
@@ -75,6 +75,12 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 		defer os.Remove(tmpFile)
 	}
 
+	// Strip the agent's environment from the child. We only forward a
+	// minimal set of OS env vars — anything secret-shaped that the agent
+	// inherited (ARKTIS_KEY, cloud creds, systemd EnvironmentFile entries)
+	// is deliberately excluded so a backend-issued `env` can't exfiltrate it.
+	cmd.Env = minimalEnv()
+
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf

--- a/internal/executor/env_linux.go
+++ b/internal/executor/env_linux.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package executor
+
+import "os"
+
+// minimalEnv returns the env vars that we propagate to child processes.
+// Anything not listed here (e.g. ARKTIS_KEY, AWS_*, GITHUB_TOKEN,
+// LD_PRELOAD, systemd EnvironmentFile secrets) is deliberately stripped
+// so a backend-issued `env` cannot exfiltrate them via stdout.
+func minimalEnv() []string {
+	env := []string{
+		"PATH=" + getenvDefault("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"),
+		"LANG=" + getenvDefault("LANG", "C.UTF-8"),
+	}
+	for _, k := range []string{"HOME", "USER", "LOGNAME", "SHELL"} {
+		if v := os.Getenv(k); v != "" {
+			env = append(env, k+"="+v)
+		}
+	}
+	return env
+}
+
+func getenvDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/internal/executor/env_windows.go
+++ b/internal/executor/env_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package executor
+
+import "os"
+
+// minimalEnv returns the env vars that we propagate to child processes.
+// Windows tools (PowerShell in particular) lean on a wider set of
+// system-defined variables than Unix shells, so the allowlist is larger
+// — but it still excludes anything the agent's launcher might have
+// injected (registration key, cloud creds, CI tokens, etc.).
+func minimalEnv() []string {
+	keys := []string{
+		"SystemRoot", "SystemDrive", "windir",
+		"PATH", "PATHEXT",
+		"COMSPEC",
+		"USERPROFILE", "USERNAME", "USERDOMAIN",
+		"HOMEDRIVE", "HOMEPATH",
+		"TEMP", "TMP",
+		"ProgramFiles", "ProgramFiles(x86)", "ProgramW6432",
+		"ProgramData", "ALLUSERSPROFILE",
+		"APPDATA", "LOCALAPPDATA",
+		"PUBLIC",
+		"PSModulePath",
+	}
+	env := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			env = append(env, k+"="+v)
+		}
+	}
+	return env
+}

--- a/internal/executor/shell_linux.go
+++ b/internal/executor/shell_linux.go
@@ -8,10 +8,62 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/creack/pty"
 )
+
+// linuxShellAllowlist is the fixed set of shells the agent will fall back
+// to when $SHELL is unset or fails validation. Anything outside this list
+// can still be requested via $SHELL but only if it passes validateShell.
+var linuxShellAllowlist = []string{"/bin/bash", "/bin/sh", "/bin/zsh"}
+
+// resolveLinuxShell picks the shell used for interactive PTY sessions.
+// $SHELL is honoured only if it points at an absolute, existing, regular
+// file owned by root and not world-writable. Otherwise we fall back to a
+// fixed allowlist so an attacker who can flip env vars on the agent's
+// process token (systemd unit, scheduled task) can't pivot the agent
+// into running an arbitrary binary as root.
+func resolveLinuxShell() string {
+	if v := os.Getenv("SHELL"); v != "" {
+		if path, ok := validateShell(v); ok {
+			return path
+		}
+		log.Printf("Warning: $SHELL %q failed validation; falling back to shell allowlist", v)
+	}
+	for _, c := range linuxShellAllowlist {
+		if path, ok := validateShell(c); ok {
+			return path
+		}
+	}
+	return "/bin/sh"
+}
+
+// validateShell enforces the safety properties documented on
+// resolveLinuxShell. The returned path is filepath.Clean'd.
+func validateShell(p string) (string, bool) {
+	clean := filepath.Clean(p)
+	if !filepath.IsAbs(clean) {
+		return "", false
+	}
+	fi, err := os.Stat(clean)
+	if err != nil {
+		return "", false
+	}
+	if !fi.Mode().IsRegular() {
+		return "", false
+	}
+	if fi.Mode().Perm()&0o002 != 0 {
+		return "", false
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok || st.Uid != 0 {
+		return "", false
+	}
+	return clean, true
+}
 
 // PtySession wraps an interactive PTY shell session on Linux.
 type PtySession struct {
@@ -24,13 +76,10 @@ type PtySession struct {
 
 // NewPtySession creates and starts a new PTY session with the user's shell.
 func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtySession, error) {
-	shell := os.Getenv("SHELL")
-	if shell == "" {
-		shell = "/bin/bash"
-	}
+	shell := resolveLinuxShell()
 
 	cmd := exec.Command(shell)
-	cmd.Env = append(os.Environ(), "TERM="+sanitizeTerm(termType))
+	cmd.Env = append(minimalEnv(), "TERM="+sanitizeTerm(termType))
 
 	ptmx, err := pty.Start(cmd)
 	if err != nil {

--- a/internal/executor/shell_windows.go
+++ b/internal/executor/shell_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/UserExistsError/conpty"
@@ -25,10 +26,7 @@ type PtySession struct {
 // On Windows 10 1809+ / Server 2019+, ConPTY is the modern pseudo-console
 // API. Earlier Windows versions are not supported.
 //
-// Shell resolution order:
-//  1. %COMSPEC% env var (typically cmd.exe)
-//  2. powershell.exe (via PATH)
-//  3. cmd.exe fallback
+// See resolveWindowsShell for the shell-resolution order.
 func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtySession, error) {
 	shell := resolveWindowsShell()
 
@@ -36,6 +34,7 @@ func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtyS
 
 	cpty, err := conpty.Start(shell,
 		conpty.ConPtyDimensions(int(colsU), int(rowsU)),
+		conpty.ConPtyEnv(minimalEnv()),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("start conpty with %q: %w", shell, err)
@@ -49,23 +48,67 @@ func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtyS
 }
 
 // resolveWindowsShell picks the best available shell on the host.
+//
+// Resolution order (first existing absolute path wins):
+//  1. ARKTIS_PTY_SHELL — operator override; must be an absolute path.
+//  2. %ProgramFiles%\PowerShell\7\pwsh.exe — PowerShell 7+.
+//  3. %ProgramW6432%\PowerShell\7\pwsh.exe — PS7 from a 32-bit process.
+//  4. %SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe — Windows PS 5.1.
+//  5. %ComSpec% — only if absolute and exists.
+//  6. %SystemRoot%\System32\cmd.exe — last-resort absolute path.
+//
+// We deliberately never return a bare "cmd.exe" string: relying on PATH at
+// CreateProcess time would let any directory earlier on PATH (e.g. a
+// writable user dir) hijack the agent's shell.
 func resolveWindowsShell() string {
-	if comspec := os.Getenv("COMSPEC"); comspec != "" {
-		if _, err := os.Stat(comspec); err == nil {
-			return comspec
-		}
-	}
-	// Prefer powershell for a more useful interactive experience.
-	candidates := []string{
-		`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`,
-		`C:\Windows\System32\cmd.exe`,
-	}
+	candidates := windowsShellCandidates()
 	for _, c := range candidates {
-		if _, err := os.Stat(c); err == nil {
+		if c == "" {
+			continue
+		}
+		if !filepath.IsAbs(c) {
+			continue
+		}
+		if fi, err := os.Stat(c); err == nil && !fi.IsDir() {
 			return c
 		}
 	}
-	return "cmd.exe"
+	// Final guaranteed-absolute fallback. ConPTY may still fail here, but
+	// at least we won't be PATH-hijackable.
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	fallback := filepath.Join(systemRoot, `System32`, `cmd.exe`)
+	log.Printf("Warning: no preferred shell found, using fallback %s", fallback)
+	return fallback
+}
+
+func windowsShellCandidates() []string {
+	systemRoot := os.Getenv("SystemRoot")
+	programFiles := os.Getenv("ProgramFiles")
+	programW6432 := os.Getenv("ProgramW6432")
+
+	var c []string
+	if v := os.Getenv("ARKTIS_PTY_SHELL"); v != "" {
+		c = append(c, v)
+	}
+	if programFiles != "" {
+		c = append(c, filepath.Join(programFiles, "PowerShell", "7", "pwsh.exe"))
+	}
+	if programW6432 != "" && programW6432 != programFiles {
+		c = append(c, filepath.Join(programW6432, "PowerShell", "7", "pwsh.exe"))
+	}
+	if systemRoot != "" {
+		c = append(c, filepath.Join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"))
+	}
+	if comspec := os.Getenv("ComSpec"); comspec != "" && filepath.IsAbs(comspec) {
+		c = append(c, comspec)
+	}
+	if systemRoot != "" {
+		c = append(c, filepath.Join(systemRoot, "System32", "cmd.exe"))
+	}
+	return c
 }
 
 // Write sends input data to the ConPTY.


### PR DESCRIPTION
## Summary

Third batch of issue fixes:

- **#25** — main no longer treats every state-load failure as "first boot". Only `fs.ErrNotExist` falls through to a fresh `State{}`; permission denied / corrupt JSON / failing disk now `log.Fatalf` rather than silently re-registering and orphaning the previous host record.
- **#19** — spawned shells (both exec and PTY) get a per-OS whitelisted env via `minimalEnv()` instead of the agent's full `os.Environ()`. `ARKTIS_KEY`, `AWS_*`, `GITHUB_TOKEN`, EnvironmentFile secrets, and `LD_PRELOAD` are no longer leaked through `env` over WS.
- **#22** — `$SHELL` is honoured for PTY only when it points at an absolute, regular file owned by uid 0 and not world-writable. Otherwise we fall back to `/bin/bash`, `/bin/sh`, `/bin/zsh` — the fixed allowlist documented in the issue.
- **#29** — Windows shell discovery now prefers `pwsh.exe` under `%ProgramFiles%`/`%ProgramW6432%`, supports an `ARKTIS_PTY_SHELL` override, and always returns an absolute path. The `return "cmd.exe"` (PATH-hijack) fallback is gone.
- **#26** — `golang.org/x/sys` bumped `0.8.0 -> 0.30.0`, the latest version whose `go` directive (`go 1.18`) stays within our existing `go 1.22` toolchain requirement. Going higher (v0.31.0+) would force `go 1.23.0`+.

## Test plan

- [x] `go build ./...` clean on `linux`
- [x] `go vet ./...` clean on `linux`
- [x] `GOOS=windows go build ./...` clean
- [x] `GOOS=windows go vet ./...` clean
- [x] `go mod tidy` clean
- [ ] Manual: run `env` over an exec; verify `ARKTIS_KEY`, `AWS_*`, `GITHUB_TOKEN` are absent
- [ ] Manual (Linux): set `SHELL=/tmp/evil` (mode 0777); verify the PTY uses `/bin/bash` and a warning is logged
- [ ] Manual (Windows): on a host with PowerShell 7 installed, verify the PTY uses `pwsh.exe`
- [ ] Manual: corrupt `state.json`; verify the agent refuses to start instead of re-registering

https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz)_