### PR TITLE
fix: id validation, output sanitisation, dedupe, capacity caps, sudo opt-in

### DIFF
--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"syscall"
 
 	"github.com/bisskar/arktis-agent/internal/config"
@@ -36,6 +37,12 @@ func main() {
 	url := flag.String("url", "", "Backend WebSocket URL (required)")
 	key := flag.String("key", "", "Registration key (required)")
 	stateDir := flag.String("state-dir", defaultStateDir(), "Directory for persistent state")
+	allowElevation := flag.Bool("allow-elevation", envBool("ARKTIS_ALLOW_ELEVATION", false),
+		"Honour exec messages with elevation_required=true (otherwise: refuse with exit_code=126)")
+	maxExec := flag.Int("max-exec-concurrency", envInt("ARKTIS_MAX_EXEC", 8),
+		"Maximum simultaneous in-flight exec commands; further requests are rejected with exit_code=503")
+	maxPty := flag.Int("max-pty-sessions", envInt("ARKTIS_MAX_PTY", 4),
+		"Maximum simultaneous PTY sessions; further opens are rejected with reason=\"agent at pty capacity\"")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -92,8 +99,17 @@ func main() {
 	// Inject version into the connection package for registration messages.
 	connection.SetVersion(Version)
 
+	if *allowElevation {
+		log.Printf("Elevation enabled: backend-issued elevation_required=true commands will run via sudo")
+	}
+
 	// Create session manager and WebSocket client.
-	mgr := session.NewManager(scriptsDir)
+	mgr := session.NewManager(session.Config{
+		ScriptsDir:     scriptsDir,
+		MaxExec:        *maxExec,
+		MaxPty:         *maxPty,
+		AllowElevation: *allowElevation,
+	})
 	client := connection.NewClient(cfg, state, mgr)
 
 	// Context with OS signal cancellation.
@@ -120,4 +136,30 @@ func main() {
 	}
 
 	log.Println("arktis-agent stopped")
+}
+
+func envBool(key string, fallback bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		log.Printf("Warning: ignoring %s=%q: %v", key, v, err)
+		return fallback
+	}
+	return b
+}
+
+func envInt(key string, fallback int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		log.Printf("Warning: ignoring %s=%q: must be a positive integer", key, v)
+		return fallback
+	}
+	return n
 }

--- a/internal/connection/protocol.go
+++ b/internal/connection/protocol.go
@@ -6,10 +6,10 @@ package connection
 
 // RegisterMessage is sent on every WebSocket connect to identify the agent.
 type RegisterMessage struct {
-	Type         string `json:"type"`                    // "register"
-	HostID       string `json:"host_id,omitempty"`       // empty on first connect
+	Type         string `json:"type"`              // "register"
+	HostID       string `json:"host_id,omitempty"` // empty on first connect
 	Hostname     string `json:"hostname"`
-	Platform     string `json:"platform"`                // "windows" or "linux"
+	Platform     string `json:"platform"` // "windows" or "linux"
 	OsFamily     string `json:"os_family"`
 	OsVersion    string `json:"os_version"`
 	AgentVersion string `json:"agent_version"`
@@ -21,11 +21,21 @@ type HeartbeatMessage struct {
 }
 
 // ExecResultMessage reports the outcome of a command execution.
+//
+// stdout/stderr carry the process bytes verbatim (after the 1 MiB cap)
+// for terminal-aware consumers. stdout_safe/stderr_safe are the same
+// content with C0 control chars escaped, suitable for plain-text logs
+// and SIEM ingestion that would otherwise be vulnerable to log/terminal
+// injection from third-party command output.
 type ExecResultMessage struct {
 	Type            string  `json:"type"` // "exec_result"
 	RequestID       string  `json:"request_id"`
 	Stdout          string  `json:"stdout"`
 	Stderr          string  `json:"stderr"`
+	StdoutSafe      string  `json:"stdout_safe"`
+	StderrSafe      string  `json:"stderr_safe"`
+	StdoutTruncated bool    `json:"stdout_truncated"`
+	StderrTruncated bool    `json:"stderr_truncated"`
 	ExitCode        int     `json:"exit_code"`
 	DurationSeconds float64 `json:"duration_seconds"`
 }

--- a/internal/executor/command.go
+++ b/internal/executor/command.go
@@ -13,6 +13,16 @@ import (
 
 const maxOutputBytes = 1 * 1024 * 1024 // 1 MB
 
+// ExecResult is the outcome of running a backend-issued command.
+type ExecResult struct {
+	Stdout          string
+	Stderr          string
+	StdoutTruncated bool
+	StderrTruncated bool
+	ExitCode        int
+	DurationSeconds float64
+}
+
 // ExecuteCommand runs a command through the specified shell WITHOUT encoding.
 //
 // Commands are executed in plain text so that detection rules (EDR, Sysmon,
@@ -21,15 +31,15 @@ const maxOutputBytes = 1 * 1024 * 1024 // 1 MB
 // are invisible to most detection rules.
 //
 // Shell dispatch:
-//   - powershell  → powershell.exe -NoProfile -Command "<command>"
-//   - command_prompt → writes temp .bat file, runs cmd.exe /c <file>
-//   - bash → /bin/bash <tmp.sh>
-//   - sh   → /bin/sh   <tmp.sh>
+//   - powershell      → powershell.exe -NoProfile -Command -
+//   - command_prompt  → writes temp .bat file, runs cmd.exe /C <file>
+//   - bash            → /bin/bash <tmp.sh>
+//   - sh              → /bin/sh   <tmp.sh>
 //
 // scriptsDir is the agent-private directory used for staging temp scripts;
 // it must exist with mode 0700 (caller's responsibility). An unknown
 // executorName is rejected — we never silently downgrade to /bin/sh -c.
-func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName string, elevationRequired bool, timeoutSec int) (stdout string, stderr string, exitCode int, duration float64, err error) {
+func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName string, elevationRequired bool, timeoutSec int) (ExecResult, error) {
 	if timeoutSec <= 0 {
 		timeoutSec = 300
 	}
@@ -40,6 +50,7 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 	var (
 		cmd     *exec.Cmd
 		tmpFile string // staged script path; cleaned up below if non-empty
+		err     error
 	)
 
 	switch strings.ToLower(executorName) {
@@ -49,26 +60,28 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 	case "command_prompt":
 		cmd, tmpFile, err = buildCmdPromptCmd(cmdCtx, scriptsDir, command)
 		if err != nil {
-			return "", "", 1, 0, fmt.Errorf("stage cmd script: %w", err)
+			return ExecResult{ExitCode: 1}, fmt.Errorf("stage cmd script: %w", err)
 		}
 
 	case "bash":
 		cmd, tmpFile, err = buildShellCmd(cmdCtx, scriptsDir, command, "/bin/bash", elevationRequired)
 		if err != nil {
-			return "", "", 1, 0, fmt.Errorf("stage bash script: %w", err)
+			return ExecResult{ExitCode: 1}, fmt.Errorf("stage bash script: %w", err)
 		}
 
 	case "sh":
 		cmd, tmpFile, err = buildShellCmd(cmdCtx, scriptsDir, command, "/bin/sh", elevationRequired)
 		if err != nil {
-			return "", "", 1, 0, fmt.Errorf("stage sh script: %w", err)
+			return ExecResult{ExitCode: 1}, fmt.Errorf("stage sh script: %w", err)
 		}
 
 	default:
 		// Reject unknown executors instead of silently downgrading to the
 		// most permissive shell on the host.
-		return "", fmt.Sprintf("unknown executor_name %q (allowed: powershell, command_prompt, bash, sh)", executorName),
-			2, 0, fmt.Errorf("unknown executor_name %q", executorName)
+		return ExecResult{
+			Stderr:   fmt.Sprintf("unknown executor_name %q (allowed: powershell, command_prompt, bash, sh)", executorName),
+			ExitCode: 2,
+		}, fmt.Errorf("unknown executor_name %q", executorName)
 	}
 
 	if tmpFile != "" {
@@ -87,28 +100,33 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 
 	start := time.Now()
 	runErr := cmd.Run()
-	duration = time.Since(start).Seconds()
+	duration := time.Since(start).Seconds()
 
-	stdout = truncate(stdoutBuf.String(), maxOutputBytes)
-	stderr = truncate(stderrBuf.String(), maxOutputBytes)
+	stdout, stdoutTruncated := truncate(stdoutBuf.String(), maxOutputBytes)
+	stderr, stderrTruncated := truncate(stderrBuf.String(), maxOutputBytes)
 
-	exitCode = 0
+	res := ExecResult{
+		Stdout:          stdout,
+		Stderr:          stderr,
+		StdoutTruncated: stdoutTruncated,
+		StderrTruncated: stderrTruncated,
+		DurationSeconds: duration,
+	}
+
 	if runErr != nil {
 		if exitErr, ok := runErr.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
+			res.ExitCode = exitErr.ExitCode()
 		} else if cmdCtx.Err() == context.DeadlineExceeded {
-			exitCode = 124
-			stderr = truncate(stderr+"\n[TIMEOUT] Command exceeded "+fmt.Sprintf("%d", timeoutSec)+"s limit", maxOutputBytes)
-			err = fmt.Errorf("command timed out after %ds", timeoutSec)
-			return
+			res.ExitCode = 124
+			res.Stderr, res.StderrTruncated = truncate(res.Stderr+"\n[TIMEOUT] Command exceeded "+fmt.Sprintf("%d", timeoutSec)+"s limit", maxOutputBytes)
+			return res, fmt.Errorf("command timed out after %ds", timeoutSec)
 		} else {
-			exitCode = 1
-			err = fmt.Errorf("exec error: %w", runErr)
-			return
+			res.ExitCode = 1
+			return res, fmt.Errorf("exec error: %w", runErr)
 		}
 	}
 
-	return
+	return res, nil
 }
 
 // buildPowerShellCmd creates a PowerShell process that executes the command
@@ -204,9 +222,9 @@ func buildShellCmd(ctx context.Context, scriptsDir, command, shell string, eleva
 	return exec.CommandContext(ctx, shell, tmpFile), tmpFile, nil
 }
 
-func truncate(s string, maxBytes int) string {
+func truncate(s string, maxBytes int) (string, bool) {
 	if len(s) <= maxBytes {
-		return s
+		return s, false
 	}
 	// Back up to a UTF-8 rune boundary so we don't emit invalid UTF-8
 	// (which JSON encoding would later replace with U+FFFD).
@@ -214,5 +232,5 @@ func truncate(s string, maxBytes int) string {
 	for cut > 0 && !utf8.RuneStart(s[cut]) {
 		cut--
 	}
-	return s[:cut] + "\n[OUTPUT TRUNCATED at 1MB]"
+	return s[:cut] + "\n[OUTPUT TRUNCATED at 1MB]", true
 }

--- a/internal/session/ids.go
+++ b/internal/session/ids.go
@@ -1,0 +1,57 @@
+package session
+
+import (
+	"regexp"
+	"strings"
+)
+
+// idRe constrains untrusted ids (session_id, request_id) to a small,
+// log-safe charset and length. Anything outside this set is rejected at
+// the message-handler boundary so it never lands in a sync.Map key, in
+// log output, or in a downstream message.
+var idRe = regexp.MustCompile(`^[A-Za-z0-9_\-]{1,64}$`)
+
+// validID reports whether s is a safe session_id / request_id.
+func validID(s string) bool {
+	return idRe.MatchString(s)
+}
+
+// sanitizeOutput returns s with C0 control chars (and DEL) escaped as
+// `\xNN`, except for newline and tab which are kept verbatim. Used to
+// build the *_safe fields on ExecResultMessage so a backend that writes
+// stdout into plain-text logs / SIEM cannot have its log lines mangled
+// by ANSI escapes, CRs, BEL, or NUL bytes from the executed command.
+func sanitizeOutput(s string) string {
+	if !needsSanitize(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '\n' || c == '\t':
+			b.WriteByte(c)
+		case c < 0x20 || c == 0x7f:
+			b.WriteString(hexEscape(c))
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}
+
+func needsSanitize(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < 0x20 && c != '\n' && c != '\t') || c == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+func hexEscape(c byte) string {
+	const hex = "0123456789abcdef"
+	return `\x` + string([]byte{hex[c>>4], hex[c&0x0f]})
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -61,6 +61,10 @@ type ExecResultMessage struct {
 	RequestID       string  `json:"request_id"`
 	Stdout          string  `json:"stdout"`
 	Stderr          string  `json:"stderr"`
+	StdoutSafe      string  `json:"stdout_safe"`
+	StderrSafe      string  `json:"stderr_safe"`
+	StdoutTruncated bool    `json:"stdout_truncated"`
+	StderrTruncated bool    `json:"stderr_truncated"`
 	ExitCode        int     `json:"exit_code"`
 	DurationSeconds float64 `json:"duration_seconds"`
 }
@@ -79,30 +83,99 @@ type PtyClosedMessage struct {
 	Reason    string `json:"reason"`
 }
 
-// Manager tracks concurrent command executions and PTY sessions.
+// Default capacity caps. Operators can override via Config.
+const (
+	defaultMaxExec = 8
+	defaultMaxPty  = 4
+)
+
+// Config bundles operator-tunable knobs that flow from main into the
+// Manager. ScriptsDir is required; everything else falls back to safe
+// defaults documented above.
+type Config struct {
+	ScriptsDir     string
+	MaxExec        int
+	MaxPty         int
+	AllowElevation bool
+}
+
+// Manager tracks concurrent command executions and PTY sessions and
+// enforces the agent's local policy: capacity limits (#16), duplicate
+// session_id rejection (#12), and the elevation opt-in gate (#6).
 type Manager struct {
+	scriptsDir     string
+	allowElevation bool
+	execSem        chan struct{}
+	ptySem         chan struct{}
+
 	ptySessions sync.Map // sessionID -> *executor.PtySession
-	scriptsDir  string   // agent-private dir for staging exec scripts
 }
 
-// NewManager creates a new session manager. scriptsDir must already exist
-// with mode 0700; ExecuteCommand stages each command's temp script there
-// instead of in the world-readable system temp directory.
-func NewManager(scriptsDir string) *Manager {
-	return &Manager{scriptsDir: scriptsDir}
+// NewManager creates a new session manager.
+func NewManager(cfg Config) *Manager {
+	if cfg.MaxExec <= 0 {
+		cfg.MaxExec = defaultMaxExec
+	}
+	if cfg.MaxPty <= 0 {
+		cfg.MaxPty = defaultMaxPty
+	}
+	return &Manager{
+		scriptsDir:     cfg.ScriptsDir,
+		allowElevation: cfg.AllowElevation,
+		execSem:        make(chan struct{}, cfg.MaxExec),
+		ptySem:         make(chan struct{}, cfg.MaxPty),
+	}
 }
 
-// HandleExec executes the command directly (no encoding) and sends the result back.
-// Commands are run in plain text so detection rules can see them in process events.
-// Intended to be called in a goroutine.
+// HandleExec executes the command directly (no encoding) and sends the
+// result back. Commands are run in plain text so detection rules can see
+// them in process events. Intended to be called in a goroutine.
 //
 // ctx is the agent's root context — cancelling it (e.g. on SIGTERM) will
 // kill the child process so we don't block shutdown waiting for a long
 // command to finish.
 func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sender) {
-	log.Printf("Executing command (request_id=%s, executor=%s)", msg.RequestID, msg.ExecutorName)
+	if !validID(msg.RequestID) {
+		log.Printf("Rejecting exec with invalid request_id %q", msg.RequestID)
+		return
+	}
 
-	stdout, stderr, exitCode, duration, err := executor.ExecuteCommand(
+	// Capacity gate: refuse rather than queue when at the configured limit.
+	select {
+	case m.execSem <- struct{}{}:
+		defer func() { <-m.execSem }()
+	default:
+		log.Printf("Rejecting exec request_id=%q: agent at exec capacity", msg.RequestID)
+		sender.Send(ExecResultMessage{
+			Type:       "exec_result",
+			RequestID:  msg.RequestID,
+			Stderr:     "agent at exec capacity, retry later",
+			StderrSafe: "agent at exec capacity, retry later",
+			ExitCode:   503,
+		})
+		return
+	}
+
+	// Elevation gate: refuse unless the operator explicitly opted in.
+	if msg.ElevationRequired && !m.allowElevation {
+		log.Printf("Rejecting elevated exec request_id=%q: --allow-elevation not set", msg.RequestID)
+		const reason = "elevation refused: agent started without --allow-elevation"
+		sender.Send(ExecResultMessage{
+			Type:       "exec_result",
+			RequestID:  msg.RequestID,
+			Stderr:     reason,
+			StderrSafe: reason,
+			ExitCode:   126,
+		})
+		return
+	}
+	if msg.ElevationRequired {
+		log.Printf("Running elevated command (request_id=%q, executor=%q)", msg.RequestID, msg.ExecutorName)
+	} else {
+		log.Printf("Executing command (request_id=%q, executor=%q)", msg.RequestID, msg.ExecutorName)
+	}
+
+	res, err := executor.ExecuteCommand(
 		ctx,
 		m.scriptsDir,
 		msg.Command,
@@ -111,31 +184,79 @@ func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sende
 		msg.TimeoutSeconds,
 	)
 	if err != nil {
-		log.Printf("Command execution error (request_id=%s): %v", msg.RequestID, err)
+		log.Printf("Command execution error (request_id=%q): %v", msg.RequestID, err)
 	}
 
-	result := ExecResultMessage{
+	out := ExecResultMessage{
 		Type:            "exec_result",
 		RequestID:       msg.RequestID,
-		Stdout:          stdout,
-		Stderr:          stderr,
-		ExitCode:        exitCode,
-		DurationSeconds: duration,
+		Stdout:          res.Stdout,
+		Stderr:          res.Stderr,
+		StdoutSafe:      sanitizeOutput(res.Stdout),
+		StderrSafe:      sanitizeOutput(res.Stderr),
+		StdoutTruncated: res.StdoutTruncated,
+		StderrTruncated: res.StderrTruncated,
+		ExitCode:        res.ExitCode,
+		DurationSeconds: res.DurationSeconds,
 	}
 
-	if err := sender.Send(result); err != nil {
-		log.Printf("Failed to send exec result (request_id=%s): %v", msg.RequestID, err)
+	if err := sender.Send(out); err != nil {
+		log.Printf("Failed to send exec result (request_id=%q): %v", msg.RequestID, err)
 	}
 }
+
+// ptyPlaceholder marks a session_id slot as reserved while NewPtySession
+// is running, so a duplicate pty_open arriving in the meantime sees the
+// slot is taken (#12) without dereferencing a nil session.
+type ptyPlaceholder struct{}
 
 // HandlePtyOpen creates a new PTY session and starts reading output.
 // Intended to be called in a goroutine.
 func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
-	log.Printf("Opening PTY session %s (term=%s, %dx%d)", msg.SessionID, msg.TermType, msg.Cols, msg.Rows)
+	if !validID(msg.SessionID) {
+		log.Printf("Rejecting pty_open with invalid session_id %q", msg.SessionID)
+		sender.Send(PtyClosedMessage{
+			Type:      "pty_closed",
+			SessionID: msg.SessionID,
+			Reason:    "invalid session_id",
+		})
+		return
+	}
+
+	// Capacity gate.
+	select {
+	case m.ptySem <- struct{}{}:
+		defer func() { <-m.ptySem }()
+	default:
+		log.Printf("Rejecting pty_open session_id=%q: agent at pty capacity", msg.SessionID)
+		sender.Send(PtyClosedMessage{
+			Type:      "pty_closed",
+			SessionID: msg.SessionID,
+			Reason:    "agent at pty capacity",
+		})
+		return
+	}
+
+	// Reserve the slot atomically; a duplicate session_id sees the
+	// placeholder and is rejected without orphaning a real session.
+	placeholder := ptyPlaceholder{}
+	if _, loaded := m.ptySessions.LoadOrStore(msg.SessionID, placeholder); loaded {
+		log.Printf("Rejecting pty_open session_id=%q: duplicate", msg.SessionID)
+		sender.Send(PtyClosedMessage{
+			Type:      "pty_closed",
+			SessionID: msg.SessionID,
+			Reason:    "duplicate session_id",
+		})
+		return
+	}
+
+	log.Printf("Opening PTY session_id=%q (term=%q, %dx%d)", msg.SessionID, msg.TermType, msg.Cols, msg.Rows)
 
 	session, err := executor.NewPtySession(msg.SessionID, msg.TermType, msg.Cols, msg.Rows)
 	if err != nil {
-		log.Printf("Failed to open PTY session %s: %v", msg.SessionID, err)
+		log.Printf("Failed to open PTY session_id=%q: %v", msg.SessionID, err)
+		// Drop the placeholder we reserved.
+		m.ptySessions.CompareAndDelete(msg.SessionID, placeholder)
 		sender.Send(PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
@@ -144,6 +265,7 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 		return
 	}
 
+	// Replace the placeholder with the real session pointer.
 	m.ptySessions.Store(msg.SessionID, session)
 
 	// Read loop sends PTY output back to the backend.
@@ -155,10 +277,12 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 		})
 	})
 
-	// ReadLoop returned — session ended.
-	m.ptySessions.Delete(msg.SessionID)
+	// ReadLoop returned — session ended. Compare-and-delete so a later
+	// pty_open with the same session_id (which would have been rejected
+	// above as a duplicate) doesn't get its entry removed by us.
+	m.ptySessions.CompareAndDelete(msg.SessionID, session)
 	if err := session.Close(); err != nil {
-		log.Printf("PTY close error for session %s: %v", msg.SessionID, err)
+		log.Printf("PTY close error for session_id=%q: %v", msg.SessionID, err)
 	}
 
 	sender.Send(PtyClosedMessage{
@@ -167,68 +291,99 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 		Reason:    "session ended",
 	})
 
-	log.Printf("PTY session %s closed", msg.SessionID)
+	log.Printf("PTY session_id=%q closed", msg.SessionID)
 }
 
 // HandlePtyInput decodes base64 input and writes it to the PTY.
 func (m *Manager) HandlePtyInput(msg *PtyInputMessage) {
-	val, ok := m.ptySessions.Load(msg.SessionID)
-	if !ok {
-		log.Printf("PTY input for unknown session %s", msg.SessionID)
+	if !validID(msg.SessionID) {
+		log.Printf("Rejecting pty_input with invalid session_id %q", msg.SessionID)
 		return
 	}
 
-	session := val.(*executor.PtySession)
+	val, ok := m.ptySessions.Load(msg.SessionID)
+	if !ok {
+		log.Printf("PTY input for unknown session_id=%q", msg.SessionID)
+		return
+	}
+	session, ok := val.(*executor.PtySession)
+	if !ok {
+		// Placeholder still in place — session not ready yet.
+		log.Printf("PTY input for not-yet-ready session_id=%q", msg.SessionID)
+		return
+	}
+
 	data, err := base64.StdEncoding.DecodeString(msg.Data)
 	if err != nil {
-		log.Printf("Failed to decode PTY input for session %s: %v", msg.SessionID, err)
+		log.Printf("Failed to decode PTY input for session_id=%q: %v", msg.SessionID, err)
 		return
 	}
 
 	if _, err := session.Write(data); err != nil {
-		log.Printf("Failed to write to PTY session %s: %v", msg.SessionID, err)
+		log.Printf("Failed to write to PTY session_id=%q: %v", msg.SessionID, err)
 	}
 }
 
 // HandlePtyResize changes the window size of a PTY session.
 func (m *Manager) HandlePtyResize(msg *PtyResizeMessage) {
-	val, ok := m.ptySessions.Load(msg.SessionID)
-	if !ok {
-		log.Printf("PTY resize for unknown session %s", msg.SessionID)
+	if !validID(msg.SessionID) {
+		log.Printf("Rejecting pty_resize with invalid session_id %q", msg.SessionID)
 		return
 	}
 
-	session := val.(*executor.PtySession)
+	val, ok := m.ptySessions.Load(msg.SessionID)
+	if !ok {
+		log.Printf("PTY resize for unknown session_id=%q", msg.SessionID)
+		return
+	}
+	session, ok := val.(*executor.PtySession)
+	if !ok {
+		log.Printf("PTY resize for not-yet-ready session_id=%q", msg.SessionID)
+		return
+	}
+
 	if err := session.Resize(msg.Cols, msg.Rows); err != nil {
-		log.Printf("Failed to resize PTY session %s: %v", msg.SessionID, err)
+		log.Printf("Failed to resize PTY session_id=%q: %v", msg.SessionID, err)
 	}
 }
 
 // HandlePtyClose closes a PTY session and removes it from the manager.
 func (m *Manager) HandlePtyClose(msg *PtyCloseMessage) {
-	val, ok := m.ptySessions.Load(msg.SessionID)
-	if !ok {
-		log.Printf("PTY close for unknown session %s", msg.SessionID)
+	if !validID(msg.SessionID) {
+		log.Printf("Rejecting pty_close with invalid session_id %q", msg.SessionID)
 		return
 	}
 
-	session := val.(*executor.PtySession)
-	if err := session.Close(); err != nil {
-		log.Printf("PTY close error for session %s: %v", msg.SessionID, err)
+	val, ok := m.ptySessions.Load(msg.SessionID)
+	if !ok {
+		log.Printf("PTY close for unknown session_id=%q", msg.SessionID)
+		return
 	}
-	m.ptySessions.Delete(msg.SessionID)
-	log.Printf("PTY session %s closed by backend", msg.SessionID)
+	session, ok := val.(*executor.PtySession)
+	if !ok {
+		// Placeholder — let HandlePtyOpen finish setup and then exit normally.
+		log.Printf("PTY close for not-yet-ready session_id=%q", msg.SessionID)
+		return
+	}
+
+	if err := session.Close(); err != nil {
+		log.Printf("PTY close error for session_id=%q: %v", msg.SessionID, err)
+	}
+	m.ptySessions.CompareAndDelete(msg.SessionID, session)
+	log.Printf("PTY session_id=%q closed by backend", msg.SessionID)
 }
 
 // CloseAll terminates all active PTY sessions. Used during graceful shutdown.
 func (m *Manager) CloseAll() {
 	m.ptySessions.Range(func(key, val interface{}) bool {
-		session := val.(*executor.PtySession)
-		if err := session.Close(); err != nil {
-			log.Printf("PTY close error for session %s during shutdown: %v", key, err)
+		session, ok := val.(*executor.PtySession)
+		if ok {
+			if err := session.Close(); err != nil {
+				log.Printf("PTY close error for session_id=%q during shutdown: %v", key, err)
+			}
+			log.Printf("Closed PTY session_id=%q during shutdown", key)
 		}
 		m.ptySessions.Delete(key)
-		log.Printf("Closed PTY session %s during shutdown", key)
 		return true
 	})
 }


### PR DESCRIPTION
## Summary

Fourth batch of issue fixes — focused on input validation, output sanitisation, and resource policy:

- **#13** — `session_id` and `request_id` validated against `^[A-Za-z0-9_-]{1,64}$` at every handler entry point. Invalid ids are rejected (`pty_closed reason="invalid session_id"` / silent exec drop) and never become a `sync.Map` key. All `Printf` format strings for ids switched from `%s` to `%q` so CRLF injection cannot break log lines.
- **#33** — `ExecResultMessage` gains `stdout_safe`, `stderr_safe`, `stdout_truncated`, `stderr_truncated`. The `*_safe` variants escape C0 control chars (and DEL) as `\xNN` — newline and tab kept — so a backend that writes the result into plain-text logs is no longer vulnerable to ANSI/CRLF injection from third-party command output. Original `stdout`/`stderr` remain verbatim for terminal-aware consumers.
- **#12** — `HandlePtyOpen` reserves the `session_id` slot via `LoadOrStore(placeholder)` before `NewPtySession` runs, so a second `pty_open` with the same `session_id` is rejected (`pty_closed reason="duplicate session_id"`) rather than orphaning the first shell. Read-loop cleanup uses `CompareAndDelete` so a late `HandlePtyOpen` can't wipe the wrong entry.
- **#16** — Manager has bounded `execSem` / `ptySem` channel semaphores. When at capacity, new exec returns `exit_code=503` and new `pty_open` returns `reason="agent at pty capacity"` instead of queueing or fork-bombing the host. Configurable via `--max-exec-concurrency` / `--max-pty-sessions` (env: `ARKTIS_MAX_EXEC`, `ARKTIS_MAX_PTY`); defaults `8` and `4`.
- **#6** — Elevation now requires explicit operator opt-in via `--allow-elevation` (env: `ARKTIS_ALLOW_ELEVATION`). Without it, an exec with `elevation_required=true` returns `exit_code=126` and a structured stderr message; with it, the elevation attempt is logged at INFO with the `request_id`.

Side cleanups: `ExecuteCommand` now returns an `ExecResult` struct (carries the truncation flags); `main` wires the new flags through a `session.Config` rather than positional args.

## Test plan

- [x] `go build ./...` clean on `linux`
- [x] `go vet ./...` clean on `linux`
- [x] `GOOS=windows go build ./...` clean
- [x] `GOOS=windows go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [ ] Manual: send `pty_open` with `session_id="\r\nFAKE LOG\r\n"`; verify it's rejected and logs show the literal quoted string
- [ ] Manual: send two `pty_open` 1ms apart with the same `session_id`; verify the second gets `duplicate session_id`, no orphan shell
- [ ] Manual: send 9 simultaneous `exec` with `--max-exec-concurrency=8`; verify the 9th returns `exit_code=503`
- [ ] Manual: send `exec` with `elevation_required=true` (a) without `--allow-elevation` → `exit_code=126`, (b) with `--allow-elevation` → runs and logs the attempt
- [ ] Manual: send a command whose output contains `\x1b]0;evil\x07`; verify `stdout_safe` shows escaped form, `stdout` is unchanged

https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz)_