### PR TITLE
fix: protocol pkg, single-writer goroutine, PowerShell hardening, CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          # Match the latest stable minor so govulncheck sees a stdlib that
+          # has the most recent advisories applied. go.mod still pins
+          # `go 1.22` as the minimum supported toolchain.
+          go-version: 'stable'
 
       - name: Build (all platforms)
         run: make build-all
@@ -36,7 +39,10 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          # Match the latest stable minor so govulncheck sees a stdlib that
+          # has the most recent advisories applied. go.mod still pins
+          # `go 1.22` as the minimum supported toolchain.
+          go-version: 'stable'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -24,3 +27,50 @@ jobs:
 
       - name: Vet
         run: go vet ./...
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
+  gosec:
+    name: gosec
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run gosec
+        uses: securego/gosec@master
+        with:
+          # -fmt sarif emits results that GitHub code-scanning can consume.
+          # -no-fail keeps CI green if findings exist; gosec output is still
+          #  visible in the action log and uploaded as SARIF.
+          args: -fmt sarif -out gosec.sarif -no-fail -exclude-dir=.github ./...
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gosec.sarif
+
+  dependency-review:
+    name: dependency-review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -144,13 +144,18 @@ func (c *Client) connect(ctx context.Context) error {
 	}
 
 	// Wait for ack.
-	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	if err := conn.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		c.closeConn()
+		return fmt.Errorf("set ack read deadline: %w", err)
+	}
 	_, raw, err := conn.ReadMessage()
 	if err != nil {
 		c.closeConn()
 		return fmt.Errorf("read ack: %w", err)
 	}
-	conn.SetReadDeadline(time.Time{}) // Clear deadline.
+	// Clear deadline; failure here is benign — we'd just time out earlier
+	// on the next read — and the connection is healthy at this point.
+	_ = conn.SetReadDeadline(time.Time{})
 
 	var base protocol.BaseMessage
 	if err := json.Unmarshal(raw, &base); err != nil {
@@ -410,7 +415,10 @@ func (c *Client) closeConn() {
 	defer c.mu.Unlock()
 
 	if c.conn != nil {
-		c.conn.Close()
+		// Close errors here are unactionable: the connection is being torn
+		// down, and any error means it was already broken from the other
+		// side. The reconnect loop handles the recovery path.
+		_ = c.conn.Close()
 		c.conn = nil
 	}
 }
@@ -419,7 +427,9 @@ func (c *Client) closeConn() {
 // Used both by the synchronous register path and by the post-handshake
 // writer goroutine.
 func writeJSON(conn *websocket.Conn, msg interface{}) error {
-	conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err := conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
 	return conn.WriteJSON(msg)
 }
 

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/bisskar/arktis-agent/internal/config"
 	"github.com/bisskar/arktis-agent/internal/executor"
+	"github.com/bisskar/arktis-agent/internal/protocol"
 	"github.com/bisskar/arktis-agent/internal/session"
 	"github.com/gorilla/websocket"
 )
@@ -20,15 +22,32 @@ const (
 	heartbeatInterval = 15 * time.Second
 	maxBackoff        = 60 * time.Second
 	writeWait         = 10 * time.Second
+
+	// sendBufSize bounds how many messages can be queued for the
+	// writer goroutine before Send starts returning ErrSendBufferFull.
+	// A misbehaving / chatty PTY then visibly drops frames instead of
+	// silently starving every other session sharing the connection.
+	sendBufSize = 64
 )
+
+// ErrSendBufferFull is returned by Send when the writer goroutine cannot
+// keep up with producers. Callers (PTY readloop, exec result) should log
+// the back-pressure and continue rather than retry in a tight loop.
+var ErrSendBufferFull = errors.New("send buffer full")
+
+// errNotConnected indicates Send was called before the WebSocket and its
+// writer goroutine were ready, or after they wound down.
+var errNotConnected = errors.New("not connected")
 
 // Client manages the WebSocket connection to the backend.
 type Client struct {
 	config  *config.Config
 	state   *config.State
-	conn    *websocket.Conn
 	manager *session.Manager
-	mu      sync.Mutex
+
+	mu   sync.Mutex
+	conn *websocket.Conn  // active connection or nil
+	out  chan interface{} // active send queue or nil; drained by writer goroutine
 }
 
 // NewClient creates a new WebSocket client.
@@ -105,9 +124,12 @@ func (c *Client) connect(ctx context.Context) error {
 
 	log.Println("WebSocket connected, sending registration...")
 
-	// Send register message.
+	// Pre-handshake (register + ack) is done synchronously on the
+	// connection: the writer goroutine isn't running yet, so we don't
+	// need to coordinate with it. After the ack we install the queue
+	// and switch all Send calls to non-blocking enqueue.
 	hostname, _ := os.Hostname()
-	reg := RegisterMessage{
+	reg := protocol.RegisterMessage{
 		Type:         "register",
 		HostID:       c.state.HostID,
 		Hostname:     hostname,
@@ -116,7 +138,7 @@ func (c *Client) connect(ctx context.Context) error {
 		OsVersion:    executor.DetectOsVersion(),
 		AgentVersion: getVersion(),
 	}
-	if err := c.Send(reg); err != nil {
+	if err := writeJSON(conn, reg); err != nil {
 		c.closeConn()
 		return fmt.Errorf("send register: %w", err)
 	}
@@ -130,7 +152,7 @@ func (c *Client) connect(ctx context.Context) error {
 	}
 	conn.SetReadDeadline(time.Time{}) // Clear deadline.
 
-	var base BaseMessage
+	var base protocol.BaseMessage
 	if err := json.Unmarshal(raw, &base); err != nil {
 		c.closeConn()
 		return fmt.Errorf("parse ack: %w", err)
@@ -141,7 +163,7 @@ func (c *Client) connect(ctx context.Context) error {
 		return fmt.Errorf("expected ack, got %q", base.Type)
 	}
 
-	var ack AckMessage
+	var ack protocol.AckMessage
 	if err := json.Unmarshal(raw, &ack); err != nil {
 		c.closeConn()
 		return fmt.Errorf("parse ack payload: %w", err)
@@ -178,8 +200,28 @@ func (c *Client) connect(ctx context.Context) error {
 		log.Printf("Re-connected with host_id=%s", c.state.HostID)
 	}
 
-	// Connection established — reset backoff is handled by the caller observing success.
-	// We signal success by running the read loop (which blocks until disconnect).
+	// Install the per-connection send queue and start the writer goroutine.
+	// All post-handshake Send() calls go through this queue so a chatty PTY
+	// can no longer hold a single mutex and starve heartbeats / other sessions.
+	out := make(chan interface{}, sendBufSize)
+	c.mu.Lock()
+	c.out = out
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		if c.out == out {
+			c.out = nil
+		}
+		c.mu.Unlock()
+		close(out)
+	}()
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		c.writeLoop(ctx, conn, out)
+	}()
+	defer func() { <-writerDone }()
 
 	// Start heartbeat goroutine. Both the per-connection done channel and
 	// the cancel func are scoped to this call frame: deferred close/cancel
@@ -206,13 +248,37 @@ func (c *Client) connect(ctx context.Context) error {
 	defer close(closeOnCancelDone)
 
 	// Read loop blocks until error or context cancellation.
-	c.readLoop(ctx)
+	c.readLoop(ctx, conn)
 
 	return nil
 }
 
+// writeLoop drains the send queue, serializing all post-handshake writes
+// to the WebSocket. Exits when the queue is closed (connect() returning)
+// or when WriteJSON fails (which also tears down the connection).
+func (c *Client) writeLoop(ctx context.Context, conn *websocket.Conn, out <-chan interface{}) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-out:
+			if !ok {
+				return
+			}
+			if err := writeJSON(conn, msg); err != nil {
+				log.Printf("WebSocket write error: %v", err)
+				// Tear the connection down so readLoop returns and we
+				// trigger a reconnect rather than silently losing more
+				// messages.
+				c.closeConn()
+				return
+			}
+		}
+	}
+}
+
 // readLoop reads and dispatches messages from the backend.
-func (c *Client) readLoop(ctx context.Context) {
+func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn) {
 	defer c.closeConn()
 
 	for {
@@ -222,7 +288,7 @@ func (c *Client) readLoop(ctx context.Context) {
 		default:
 		}
 
-		_, raw, err := c.conn.ReadMessage()
+		_, raw, err := conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
 				log.Printf("WebSocket read error: %v", err)
@@ -232,7 +298,7 @@ func (c *Client) readLoop(ctx context.Context) {
 			return
 		}
 
-		var base BaseMessage
+		var base protocol.BaseMessage
 		if err := json.Unmarshal(raw, &base); err != nil {
 			log.Printf("Failed to parse message type: %v", err)
 			continue
@@ -240,7 +306,7 @@ func (c *Client) readLoop(ctx context.Context) {
 
 		switch base.Type {
 		case "exec":
-			var msg session.ExecMessage
+			var msg protocol.ExecMessage
 			if err := json.Unmarshal(raw, &msg); err != nil {
 				log.Printf("Failed to parse exec message: %v", err)
 				continue
@@ -248,7 +314,7 @@ func (c *Client) readLoop(ctx context.Context) {
 			go c.manager.HandleExec(ctx, &msg, c)
 
 		case "pty_open":
-			var msg session.PtyOpenMessage
+			var msg protocol.PtyOpenMessage
 			if err := json.Unmarshal(raw, &msg); err != nil {
 				log.Printf("Failed to parse pty_open message: %v", err)
 				continue
@@ -256,7 +322,7 @@ func (c *Client) readLoop(ctx context.Context) {
 			go c.manager.HandlePtyOpen(&msg, c)
 
 		case "pty_input":
-			var msg session.PtyInputMessage
+			var msg protocol.PtyInputMessage
 			if err := json.Unmarshal(raw, &msg); err != nil {
 				log.Printf("Failed to parse pty_input message: %v", err)
 				continue
@@ -264,7 +330,7 @@ func (c *Client) readLoop(ctx context.Context) {
 			c.manager.HandlePtyInput(&msg)
 
 		case "pty_resize":
-			var msg session.PtyResizeMessage
+			var msg protocol.PtyResizeMessage
 			if err := json.Unmarshal(raw, &msg); err != nil {
 				log.Printf("Failed to parse pty_resize message: %v", err)
 				continue
@@ -272,7 +338,7 @@ func (c *Client) readLoop(ctx context.Context) {
 			c.manager.HandlePtyResize(&msg)
 
 		case "pty_close":
-			var msg session.PtyCloseMessage
+			var msg protocol.PtyCloseMessage
 			if err := json.Unmarshal(raw, &msg); err != nil {
 				log.Printf("Failed to parse pty_close message: %v", err)
 				continue
@@ -303,30 +369,41 @@ func (c *Client) heartbeatLoop(ctx context.Context, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			if err := c.Send(HeartbeatMessage{Type: "heartbeat"}); err != nil {
-				log.Printf("Failed to send heartbeat: %v", err)
-				return
+			if err := c.Send(protocol.HeartbeatMessage{Type: "heartbeat"}); err != nil {
+				log.Printf("Failed to enqueue heartbeat: %v", err)
+				// Don't return on a backpressure-only failure — we'll
+				// try again next tick. A genuine teardown is signalled
+				// through ctx / done.
+				if !errors.Is(err, ErrSendBufferFull) {
+					return
+				}
 			}
 		}
 	}
 }
 
-// Send marshals msg to JSON and writes it to the WebSocket. Thread-safe.
+// Send enqueues msg onto the writer goroutine's queue. It is non-blocking:
+// if the queue is full it returns ErrSendBufferFull immediately so a
+// misbehaving sender (e.g. a chatty PTY) can never starve other senders
+// or hold a write mutex across slow network frames.
 func (c *Client) Send(msg interface{}) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.conn == nil {
-		return fmt.Errorf("not connected")
+	out := c.out
+	c.mu.Unlock()
+	if out == nil {
+		return errNotConnected
 	}
-
-	c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-	return c.conn.WriteJSON(msg)
+	select {
+	case out <- msg:
+		return nil
+	default:
+		return ErrSendBufferFull
+	}
 }
 
 // closeConn safely closes the WebSocket connection. The per-connection
-// heartbeat goroutine is wound down by connect()'s deferred close(hbDone)
-// rather than by this function — closeConn may be called multiple times
+// heartbeat / writer goroutines are wound down by connect()'s deferred
+// close(hbDone) and queue close — closeConn may be called multiple times
 // (read-loop exit, ctx-cancel goroutine) and must remain idempotent.
 func (c *Client) closeConn() {
 	c.mu.Lock()
@@ -336,6 +413,14 @@ func (c *Client) closeConn() {
 		c.conn.Close()
 		c.conn = nil
 	}
+}
+
+// writeJSON is the single point where we set the write deadline + marshal.
+// Used both by the synchronous register path and by the post-handshake
+// writer goroutine.
+func writeJSON(conn *websocket.Conn, msg interface{}) error {
+	conn.SetWriteDeadline(time.Now().Add(writeWait))
+	return conn.WriteJSON(msg)
 }
 
 // getVersion returns the agent version (set via ldflags in main).

--- a/internal/executor/command.go
+++ b/internal/executor/command.go
@@ -198,12 +198,12 @@ func buildCmdPromptCmd(ctx context.Context, scriptsDir, command string) (*exec.C
 	// Ensure CRLF line endings for Windows batch files.
 	script := strings.ReplaceAll(command, "\n", "\r\n")
 	if _, err := f.WriteString(script); err != nil {
-		f.Close()
-		os.Remove(tmpFile)
+		_ = f.Close()
+		_ = os.Remove(tmpFile)
 		return nil, "", fmt.Errorf("write temp script: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmpFile)
+		_ = os.Remove(tmpFile)
 		return nil, "", fmt.Errorf("close temp script: %w", err)
 	}
 
@@ -229,12 +229,12 @@ func buildShellCmd(ctx context.Context, scriptsDir, command, shell string, eleva
 
 	script := fmt.Sprintf("#!%s\n%s\n", shell, command)
 	if _, err := f.WriteString(script); err != nil {
-		f.Close()
-		os.Remove(tmpFile)
+		_ = f.Close()
+		_ = os.Remove(tmpFile)
 		return nil, "", fmt.Errorf("write temp script: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmpFile)
+		_ = os.Remove(tmpFile)
 		return nil, "", fmt.Errorf("close temp script: %w", err)
 	}
 

--- a/internal/executor/command.go
+++ b/internal/executor/command.go
@@ -13,6 +13,19 @@ import (
 
 const maxOutputBytes = 1 * 1024 * 1024 // 1 MB
 
+// ExecRequest bundles the inputs to ExecuteCommand. Using a struct keeps
+// the call site readable as the parameter list grows (e.g. opt-in
+// PowerShell preference suppression).
+type ExecRequest struct {
+	Ctx                context.Context
+	ScriptsDir         string
+	Command            string
+	ExecutorName       string
+	ElevationRequired  bool
+	TimeoutSeconds     int
+	SilencePreferences bool
+}
+
 // ExecResult is the outcome of running a backend-issued command.
 type ExecResult struct {
 	Stdout          string
@@ -31,20 +44,22 @@ type ExecResult struct {
 // are invisible to most detection rules.
 //
 // Shell dispatch:
-//   - powershell      → powershell.exe -NoProfile -Command -
+//   - powershell      → powershell.exe -NoProfile -NonInteractive -Command -
 //   - command_prompt  → writes temp .bat file, runs cmd.exe /C <file>
 //   - bash            → /bin/bash <tmp.sh>
 //   - sh              → /bin/sh   <tmp.sh>
 //
-// scriptsDir is the agent-private directory used for staging temp scripts;
-// it must exist with mode 0700 (caller's responsibility). An unknown
-// executorName is rejected — we never silently downgrade to /bin/sh -c.
-func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName string, elevationRequired bool, timeoutSec int) (ExecResult, error) {
+// req.ScriptsDir is the agent-private directory used for staging temp
+// scripts; it must exist with mode 0700 (caller's responsibility). An
+// unknown ExecutorName is rejected — we never silently downgrade to
+// /bin/sh -c.
+func ExecuteCommand(req ExecRequest) (ExecResult, error) {
+	timeoutSec := req.TimeoutSeconds
 	if timeoutSec <= 0 {
 		timeoutSec = 300
 	}
 
-	cmdCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+	cmdCtx, cancel := context.WithTimeout(req.Ctx, time.Duration(timeoutSec)*time.Second)
 	defer cancel()
 
 	var (
@@ -53,24 +68,24 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 		err     error
 	)
 
-	switch strings.ToLower(executorName) {
+	switch strings.ToLower(req.ExecutorName) {
 	case "powershell":
-		cmd = buildPowerShellCmd(cmdCtx, command)
+		cmd = buildPowerShellCmd(cmdCtx, req.Command, req.SilencePreferences)
 
 	case "command_prompt":
-		cmd, tmpFile, err = buildCmdPromptCmd(cmdCtx, scriptsDir, command)
+		cmd, tmpFile, err = buildCmdPromptCmd(cmdCtx, req.ScriptsDir, req.Command)
 		if err != nil {
 			return ExecResult{ExitCode: 1}, fmt.Errorf("stage cmd script: %w", err)
 		}
 
 	case "bash":
-		cmd, tmpFile, err = buildShellCmd(cmdCtx, scriptsDir, command, "/bin/bash", elevationRequired)
+		cmd, tmpFile, err = buildShellCmd(cmdCtx, req.ScriptsDir, req.Command, "/bin/bash", req.ElevationRequired)
 		if err != nil {
 			return ExecResult{ExitCode: 1}, fmt.Errorf("stage bash script: %w", err)
 		}
 
 	case "sh":
-		cmd, tmpFile, err = buildShellCmd(cmdCtx, scriptsDir, command, "/bin/sh", elevationRequired)
+		cmd, tmpFile, err = buildShellCmd(cmdCtx, req.ScriptsDir, req.Command, "/bin/sh", req.ElevationRequired)
 		if err != nil {
 			return ExecResult{ExitCode: 1}, fmt.Errorf("stage sh script: %w", err)
 		}
@@ -79,9 +94,9 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 		// Reject unknown executors instead of silently downgrading to the
 		// most permissive shell on the host.
 		return ExecResult{
-			Stderr:   fmt.Sprintf("unknown executor_name %q (allowed: powershell, command_prompt, bash, sh)", executorName),
+			Stderr:   fmt.Sprintf("unknown executor_name %q (allowed: powershell, command_prompt, bash, sh)", req.ExecutorName),
 			ExitCode: 2,
-		}, fmt.Errorf("unknown executor_name %q", executorName)
+		}, fmt.Errorf("unknown executor_name %q", req.ExecutorName)
 	}
 
 	if tmpFile != "" {
@@ -138,26 +153,33 @@ func ExecuteCommand(ctx context.Context, scriptsDir, command, executorName strin
 // the script block content in ScriptBlock Logging (Event ID 4104) which
 // detection rules can read.
 //
-// We also set preference variables to suppress noisy output streams
-// that interfere with clean stdout/stderr capture.
-func buildPowerShellCmd(ctx context.Context, command string) *exec.Cmd {
-	// Pipe the command via stdin to avoid all quoting issues.
-	// PowerShell's -Command - reads from stdin.
-	// ScriptBlock Logging (4104) still captures the full script text.
-	preamble := "$ProgressPreference='SilentlyContinue';" +
-		"$InformationPreference='SilentlyContinue';" +
-		"$WarningPreference='SilentlyContinue';" +
-		"$ErrorActionPreference='Continue';\n"
-
-	fullScript := preamble + command
-
+// We deliberately do NOT pass -ExecutionPolicy Bypass: it's a
+// high-fidelity malicious-PowerShell indicator that EDR rules look for,
+// and the agent has no business pretending to be malware on the host.
+// If the host policy is Restricted/AllSigned the test should fail loudly
+// rather than be smuggled past it.
+//
+// silencePreferences is opt-in per-test: when false (the default), the
+// preamble is omitted so $ErrorActionPreference stays at Stop and real
+// failures surface as non-zero exit. When true, the original
+// SilentlyContinue / Continue preamble is restored for atomics that
+// depend on the legacy behaviour.
+func buildPowerShellCmd(ctx context.Context, command string, silencePreferences bool) *exec.Cmd {
 	cmd := exec.CommandContext(ctx,
 		"powershell.exe",
 		"-NoProfile",
 		"-NonInteractive",
-		"-ExecutionPolicy", "Bypass",
 		"-Command", "-",
 	)
+
+	fullScript := command
+	if silencePreferences {
+		preamble := "$ProgressPreference='SilentlyContinue';" +
+			"$InformationPreference='SilentlyContinue';" +
+			"$WarningPreference='SilentlyContinue';" +
+			"$ErrorActionPreference='Continue';\n"
+		fullScript = preamble + command
+	}
 	cmd.Stdin = strings.NewReader(fullScript)
 	return cmd
 }

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -1,4 +1,11 @@
-package connection
+// Package protocol defines the wire-format messages exchanged between
+// the arktis-agent and its backend over the WebSocket connection.
+//
+// It is a leaf package with no dependencies on other internal packages,
+// which lets both connection (the transport) and session (the handlers)
+// share a single set of struct definitions instead of mirroring them and
+// risking silent drift when fields are added or renamed.
+package protocol
 
 // ---------------------------------------------------------------------------
 // Outbound messages (agent -> backend)
@@ -65,13 +72,20 @@ type AckMessage struct {
 }
 
 // ExecMessage requests command execution on the host.
+//
+// SilencePreferences is opt-in per-test PowerShell preference suppression
+// ($ProgressPreference / $WarningPreference / $InformationPreference set
+// to SilentlyContinue, $ErrorActionPreference forced to Continue). Default
+// is false so PowerShell errors fail loudly rather than masking real
+// failures as "no output, exit 0".
 type ExecMessage struct {
-	Type              string `json:"type"` // "exec"
-	RequestID         string `json:"request_id"`
-	Command           string `json:"command"`
-	ExecutorName      string `json:"executor_name"` // powershell, bash, sh, command_prompt
-	ElevationRequired bool   `json:"elevation_required"`
-	TimeoutSeconds    int    `json:"timeout_seconds"`
+	Type               string `json:"type"` // "exec"
+	RequestID          string `json:"request_id"`
+	Command            string `json:"command"`
+	ExecutorName       string `json:"executor_name"` // powershell, bash, sh, command_prompt
+	ElevationRequired  bool   `json:"elevation_required"`
+	TimeoutSeconds     int    `json:"timeout_seconds"`
+	SilencePreferences bool   `json:"silence_preferences,omitempty"`
 }
 
 // PtyOpenMessage requests a new interactive terminal session.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -7,80 +7,13 @@ import (
 	"sync"
 
 	"github.com/bisskar/arktis-agent/internal/executor"
+	"github.com/bisskar/arktis-agent/internal/protocol"
 )
 
 // Sender is the interface for sending messages back to the backend.
-// This avoids a circular import with the connection package.
+// The connection package's *Client satisfies it.
 type Sender interface {
 	Send(msg interface{}) error
-}
-
-// ExecMessage mirrors connection.ExecMessage to avoid circular imports.
-type ExecMessage struct {
-	Type              string `json:"type"`
-	RequestID         string `json:"request_id"`
-	Command           string `json:"command"`
-	ExecutorName      string `json:"executor_name"`
-	ElevationRequired bool   `json:"elevation_required"`
-	TimeoutSeconds    int    `json:"timeout_seconds"`
-}
-
-// PtyOpenMessage mirrors connection.PtyOpenMessage.
-type PtyOpenMessage struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id"`
-	TermType  string `json:"term_type"`
-	Cols      int    `json:"cols"`
-	Rows      int    `json:"rows"`
-}
-
-// PtyInputMessage mirrors connection.PtyInputMessage.
-type PtyInputMessage struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id"`
-	Data      string `json:"data"`
-}
-
-// PtyResizeMessage mirrors connection.PtyResizeMessage.
-type PtyResizeMessage struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id"`
-	Cols      int    `json:"cols"`
-	Rows      int    `json:"rows"`
-}
-
-// PtyCloseMessage mirrors connection.PtyCloseMessage.
-type PtyCloseMessage struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id"`
-}
-
-// ExecResultMessage mirrors connection.ExecResultMessage.
-type ExecResultMessage struct {
-	Type            string  `json:"type"`
-	RequestID       string  `json:"request_id"`
-	Stdout          string  `json:"stdout"`
-	Stderr          string  `json:"stderr"`
-	StdoutSafe      string  `json:"stdout_safe"`
-	StderrSafe      string  `json:"stderr_safe"`
-	StdoutTruncated bool    `json:"stdout_truncated"`
-	StderrTruncated bool    `json:"stderr_truncated"`
-	ExitCode        int     `json:"exit_code"`
-	DurationSeconds float64 `json:"duration_seconds"`
-}
-
-// PtyOutputMessage mirrors connection.PtyOutputMessage.
-type PtyOutputMessage struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id"`
-	Data      string `json:"data"`
-}
-
-// PtyClosedMessage mirrors connection.PtyClosedMessage.
-type PtyClosedMessage struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id"`
-	Reason    string `json:"reason"`
 }
 
 // Default capacity caps. Operators can override via Config.
@@ -134,7 +67,7 @@ func NewManager(cfg Config) *Manager {
 // ctx is the agent's root context — cancelling it (e.g. on SIGTERM) will
 // kill the child process so we don't block shutdown waiting for a long
 // command to finish.
-func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sender) {
+func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sender Sender) {
 	if !validID(msg.RequestID) {
 		log.Printf("Rejecting exec with invalid request_id %q", msg.RequestID)
 		return
@@ -146,7 +79,7 @@ func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sende
 		defer func() { <-m.execSem }()
 	default:
 		log.Printf("Rejecting exec request_id=%q: agent at exec capacity", msg.RequestID)
-		sender.Send(ExecResultMessage{
+		sender.Send(protocol.ExecResultMessage{
 			Type:       "exec_result",
 			RequestID:  msg.RequestID,
 			Stderr:     "agent at exec capacity, retry later",
@@ -160,7 +93,7 @@ func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sende
 	if msg.ElevationRequired && !m.allowElevation {
 		log.Printf("Rejecting elevated exec request_id=%q: --allow-elevation not set", msg.RequestID)
 		const reason = "elevation refused: agent started without --allow-elevation"
-		sender.Send(ExecResultMessage{
+		sender.Send(protocol.ExecResultMessage{
 			Type:       "exec_result",
 			RequestID:  msg.RequestID,
 			Stderr:     reason,
@@ -175,19 +108,20 @@ func (m *Manager) HandleExec(ctx context.Context, msg *ExecMessage, sender Sende
 		log.Printf("Executing command (request_id=%q, executor=%q)", msg.RequestID, msg.ExecutorName)
 	}
 
-	res, err := executor.ExecuteCommand(
-		ctx,
-		m.scriptsDir,
-		msg.Command,
-		msg.ExecutorName,
-		msg.ElevationRequired,
-		msg.TimeoutSeconds,
-	)
+	res, err := executor.ExecuteCommand(executor.ExecRequest{
+		Ctx:                ctx,
+		ScriptsDir:         m.scriptsDir,
+		Command:            msg.Command,
+		ExecutorName:       msg.ExecutorName,
+		ElevationRequired:  msg.ElevationRequired,
+		TimeoutSeconds:     msg.TimeoutSeconds,
+		SilencePreferences: msg.SilencePreferences,
+	})
 	if err != nil {
 		log.Printf("Command execution error (request_id=%q): %v", msg.RequestID, err)
 	}
 
-	out := ExecResultMessage{
+	out := protocol.ExecResultMessage{
 		Type:            "exec_result",
 		RequestID:       msg.RequestID,
 		Stdout:          res.Stdout,
@@ -212,10 +146,10 @@ type ptyPlaceholder struct{}
 
 // HandlePtyOpen creates a new PTY session and starts reading output.
 // Intended to be called in a goroutine.
-func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
+func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 	if !validID(msg.SessionID) {
 		log.Printf("Rejecting pty_open with invalid session_id %q", msg.SessionID)
-		sender.Send(PtyClosedMessage{
+		sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "invalid session_id",
@@ -229,7 +163,7 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 		defer func() { <-m.ptySem }()
 	default:
 		log.Printf("Rejecting pty_open session_id=%q: agent at pty capacity", msg.SessionID)
-		sender.Send(PtyClosedMessage{
+		sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "agent at pty capacity",
@@ -242,7 +176,7 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 	placeholder := ptyPlaceholder{}
 	if _, loaded := m.ptySessions.LoadOrStore(msg.SessionID, placeholder); loaded {
 		log.Printf("Rejecting pty_open session_id=%q: duplicate", msg.SessionID)
-		sender.Send(PtyClosedMessage{
+		sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "duplicate session_id",
@@ -257,7 +191,7 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 		log.Printf("Failed to open PTY session_id=%q: %v", msg.SessionID, err)
 		// Drop the placeholder we reserved.
 		m.ptySessions.CompareAndDelete(msg.SessionID, placeholder)
-		sender.Send(PtyClosedMessage{
+		sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    err.Error(),
@@ -268,13 +202,20 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 	// Replace the placeholder with the real session pointer.
 	m.ptySessions.Store(msg.SessionID, session)
 
-	// Read loop sends PTY output back to the backend.
+	// Read loop sends PTY output back to the backend. ErrSendBufferFull
+	// from the writer goroutine is treated as a per-frame drop (logged
+	// once per session, not per frame) so a chatty PTY doesn't spam.
+	dropLogged := false
 	session.ReadLoop(func(data []byte) {
-		sender.Send(PtyOutputMessage{
+		err := sender.Send(protocol.PtyOutputMessage{
 			Type:      "pty_output",
 			SessionID: msg.SessionID,
 			Data:      string(data), // Already base64-encoded by ReadLoop.
 		})
+		if err != nil && !dropLogged {
+			log.Printf("Dropping PTY output for session_id=%q (writer at capacity): %v", msg.SessionID, err)
+			dropLogged = true
+		}
 	})
 
 	// ReadLoop returned — session ended. Compare-and-delete so a later
@@ -285,7 +226,7 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 		log.Printf("PTY close error for session_id=%q: %v", msg.SessionID, err)
 	}
 
-	sender.Send(PtyClosedMessage{
+	sender.Send(protocol.PtyClosedMessage{
 		Type:      "pty_closed",
 		SessionID: msg.SessionID,
 		Reason:    "session ended",
@@ -295,7 +236,7 @@ func (m *Manager) HandlePtyOpen(msg *PtyOpenMessage, sender Sender) {
 }
 
 // HandlePtyInput decodes base64 input and writes it to the PTY.
-func (m *Manager) HandlePtyInput(msg *PtyInputMessage) {
+func (m *Manager) HandlePtyInput(msg *protocol.PtyInputMessage) {
 	if !validID(msg.SessionID) {
 		log.Printf("Rejecting pty_input with invalid session_id %q", msg.SessionID)
 		return
@@ -325,7 +266,7 @@ func (m *Manager) HandlePtyInput(msg *PtyInputMessage) {
 }
 
 // HandlePtyResize changes the window size of a PTY session.
-func (m *Manager) HandlePtyResize(msg *PtyResizeMessage) {
+func (m *Manager) HandlePtyResize(msg *protocol.PtyResizeMessage) {
 	if !validID(msg.SessionID) {
 		log.Printf("Rejecting pty_resize with invalid session_id %q", msg.SessionID)
 		return
@@ -348,7 +289,7 @@ func (m *Manager) HandlePtyResize(msg *PtyResizeMessage) {
 }
 
 // HandlePtyClose closes a PTY session and removes it from the manager.
-func (m *Manager) HandlePtyClose(msg *PtyCloseMessage) {
+func (m *Manager) HandlePtyClose(msg *protocol.PtyCloseMessage) {
 	if !validID(msg.SessionID) {
 		log.Printf("Rejecting pty_close with invalid session_id %q", msg.SessionID)
 		return


### PR DESCRIPTION
## Summary

Fifth batch of issue fixes — refactor + hardening + CI:

- **#27** — extract `internal/protocol` with all wire-format message types. `connection` and `session` both import it instead of mirroring structs. `internal/connection/protocol.go` is removed; the duplicate type defs at the top of `session/manager.go` are gone. Adding a JSON field now touches one file.
- **#21** — PowerShell invocation drops `-ExecutionPolicy Bypass` (a high-fidelity malicious-PowerShell EDR signature the agent has no business tripping). The preference-variable preamble that hid errors as "no output, exit 0" is moved behind a per-message `silence_preferences` flag on `protocol.ExecMessage`; default surfaces failures via `$ErrorActionPreference=Stop`.
- **#23** — post-handshake WebSocket writes flow through a bounded send-channel (size 64) + dedicated writer goroutine instead of a per-call mutex. A chatty PTY can no longer hold the write lock long enough to starve heartbeats or other sessions; when the queue is full, `Send` returns `ErrSendBufferFull` and PTY readloops drop frames with a single log line per session rather than retrying in a tight loop. Pre-handshake register/ack still uses a synchronous `WriteJSON` since correctness depends on observing the write.
- **#11** — CI gains `govulncheck`, `gosec` (with SARIF upload to code scanning), and `dependency-review` (PR-only). Existing `build-and-test` job is unchanged. SHA-pinning of third-party actions is left as a follow-up — flagged in #11.

Side cleanups:
- `ExecuteCommand` takes an `ExecRequest` struct (parameter list was growing).
- Stale `errSendBufferFull` placeholder in `session/manager.go` removed.

## Test plan

- [x] `go build ./...` clean on `linux`
- [x] `go vet ./...` clean on `linux`
- [x] `GOOS=windows go build ./...` clean
- [x] `GOOS=windows go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [ ] Manual: cause a PTY to spew (`yes | head -c 100M | base64`) and verify heartbeats keep flowing while the writer drops frames; one log line per session, not per frame
- [ ] Manual: `exec` a PowerShell command that fails (e.g. `Get-Item /nonexistent`); confirm `exit_code != 0` rather than the previous `0` with empty stdout
- [ ] Manual: send `exec` with `silence_preferences=true`; confirm the preamble is restored
- [ ] CI: confirm `govulncheck`, `gosec`, `dependency-review` jobs run; SARIF appears under Security → Code scanning

https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz)_