### PR TITLE
fix: unit tests, gen-tagged sender, JSON audit log, signed releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run gosec
-        uses: securego/gosec@master
+      - uses: actions/setup-go@v5
         with:
-          # -fmt sarif emits results that GitHub code-scanning can consume.
-          # -no-fail keeps CI green if findings exist; gosec output is still
-          #  visible in the action log and uploaded as SARIF.
-          args: -fmt sarif -out gosec.sarif -no-fail -exclude-dir=.github ./...
+          go-version: 'stable'
+
+      # Running gosec via `go install` rather than the securego/gosec
+      # action keeps the no-fail behaviour consistent with what we see
+      # locally (the action wrapper has a habit of exiting non-zero
+      # despite `-no-fail`). Findings still go to GitHub code scanning
+      # via the SARIF upload below.
+      - name: Run gosec
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          gosec -fmt sarif -out gosec.sarif -no-fail -exclude-dir=.github ./...
 
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: 'stable'
 
       - name: Build
         env:
@@ -48,10 +48,41 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write   # cosign keyless OIDC
     steps:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+
+      - name: Compute SHA-256 checksums
+        run: |
+          sha256sum \
+            arktis-agent-linux-amd64 \
+            arktis-agent-linux-arm64 \
+            arktis-agent-windows-amd64.exe \
+            > sha256sums.txt
+          cat sha256sums.txt
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Sign artifacts (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          for f in \
+            arktis-agent-linux-amd64 \
+            arktis-agent-linux-arm64 \
+            arktis-agent-windows-amd64.exe \
+            sha256sums.txt
+          do
+            cosign sign-blob \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.crt" \
+              --bundle "${f}.cosign.bundle" \
+              "${f}"
+          done
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -61,3 +92,16 @@ jobs:
             arktis-agent-linux-amd64
             arktis-agent-linux-arm64
             arktis-agent-windows-amd64.exe
+            sha256sums.txt
+            arktis-agent-linux-amd64.sig
+            arktis-agent-linux-amd64.crt
+            arktis-agent-linux-amd64.cosign.bundle
+            arktis-agent-linux-arm64.sig
+            arktis-agent-linux-arm64.crt
+            arktis-agent-linux-arm64.cosign.bundle
+            arktis-agent-windows-amd64.exe.sig
+            arktis-agent-windows-amd64.exe.crt
+            arktis-agent-windows-amd64.exe.cosign.bundle
+            sha256sums.txt.sig
+            sha256sums.txt.crt
+            sha256sums.txt.cosign.bundle

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-windows-amd64:
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(DIST)/arktis-agent-windows-amd64.exe ./cmd/arktis-agent
 
 test:
-	go test ./...
+	go test -race ./...
 
 clean:
 	rm -rf $(DIST)

--- a/README.md
+++ b/README.md
@@ -21,11 +21,31 @@ In Arktis, go to **Org Settings > Lab Hosts > Registration Keys** and click **Ge
 
 ### 2. Install the Agent
 
+Every release ships with a `sha256sums.txt` checksum manifest and a
+keyless [cosign](https://docs.sigstore.dev/cosign/overview/) signature
+bundle. Verify before running.
+
 **Linux:**
 
 ```bash
-curl -sSL https://github.com/bisskar/arktis-agent/releases/latest/download/arktis-agent-linux-amd64 \
-  -o /usr/local/bin/arktis-agent && chmod +x /usr/local/bin/arktis-agent
+RELEASE_URL=https://github.com/bisskar/arktis-agent/releases/latest/download
+
+# 1. Download the binary, the checksum manifest, and its signature bundle.
+curl -sSL "${RELEASE_URL}/arktis-agent-linux-amd64"          -o arktis-agent
+curl -sSL "${RELEASE_URL}/sha256sums.txt"                    -o sha256sums.txt
+curl -sSL "${RELEASE_URL}/sha256sums.txt.cosign.bundle"      -o sha256sums.txt.cosign.bundle
+
+# 2. Verify the checksum manifest's signature against the GitHub-issued
+#    OIDC identity. Adjust the regex if you fork the repo.
+cosign verify-blob \
+  --bundle sha256sums.txt.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/bisskar/arktis-agent/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  sha256sums.txt
+
+# 3. Verify the binary against the signed manifest, then install.
+sha256sum -c --ignore-missing sha256sums.txt
+sudo install -m 0755 arktis-agent /usr/local/bin/arktis-agent
 
 arktis-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
 ```
@@ -33,9 +53,24 @@ arktis-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
 **Windows (PowerShell):**
 
 ```powershell
-Invoke-WebRequest -Uri "https://github.com/bisskar/arktis-agent/releases/latest/download/arktis-agent-windows-amd64.exe" `
-  -OutFile "$env:ProgramFiles\arktis-agent.exe"
+$ReleaseUrl = "https://github.com/bisskar/arktis-agent/releases/latest/download"
+Invoke-WebRequest -Uri "$ReleaseUrl/arktis-agent-windows-amd64.exe"             -OutFile "arktis-agent.exe"
+Invoke-WebRequest -Uri "$ReleaseUrl/sha256sums.txt"                             -OutFile "sha256sums.txt"
+Invoke-WebRequest -Uri "$ReleaseUrl/sha256sums.txt.cosign.bundle"               -OutFile "sha256sums.txt.cosign.bundle"
 
+# Verify checksum-manifest signature (requires cosign in PATH).
+cosign verify-blob `
+  --bundle sha256sums.txt.cosign.bundle `
+  --certificate-identity-regexp '^https://github.com/bisskar/arktis-agent/' `
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com `
+  sha256sums.txt
+
+# Verify the binary against the manifest.
+$expected = (Select-String -Path sha256sums.txt -Pattern 'arktis-agent-windows-amd64.exe').Line.Split(' ')[0]
+$actual   = (Get-FileHash arktis-agent.exe -Algorithm SHA256).Hash.ToLower()
+if ($expected -ne $actual) { throw "checksum mismatch" }
+
+Move-Item -Force arktis-agent.exe "$env:ProgramFiles\arktis-agent.exe"
 & "$env:ProgramFiles\arktis-agent.exe" --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
 ```
 

--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -114,9 +114,10 @@ func main() {
 	}
 	defer auditLog.Close()
 	if *auditLogPath != "" {
-		// %q quotes the operator-supplied path to keep gosec's G706
-		// log-injection rule happy and to prevent any newline/tab in
-		// a misconfigured path from breaking log lines.
+		// Operator-supplied path (--audit-log flag); %q neutralises any
+		// embedded newline/tab. gosec G706 flags this as taint, but the
+		// "attacker" here is whoever already configured the agent's CLI.
+		// #nosec G706 -- operator input, not network input.
 		log.Printf("Audit log enabled at %q (include_command=%v)", *auditLogPath, *auditIncludeCmd)
 	}
 
@@ -163,6 +164,7 @@ func envBool(key string, fallback bool) bool {
 	}
 	b, err := strconv.ParseBool(v)
 	if err != nil {
+		// #nosec G706 -- operator-supplied env var; %q neutralises escapes.
 		log.Printf("Warning: ignoring %s=%q: %v", key, v, err)
 		return fallback
 	}
@@ -176,6 +178,7 @@ func envInt(key string, fallback int) int {
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil || n <= 0 {
+		// #nosec G706 -- operator-supplied env var; %q neutralises escapes.
 		log.Printf("Warning: ignoring %s=%q: must be a positive integer", key, v)
 		return fallback
 	}

--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/bisskar/arktis-agent/internal/audit"
 	"github.com/bisskar/arktis-agent/internal/config"
 	"github.com/bisskar/arktis-agent/internal/connection"
 	"github.com/bisskar/arktis-agent/internal/session"
@@ -43,6 +44,10 @@ func main() {
 		"Maximum simultaneous in-flight exec commands; further requests are rejected with exit_code=503")
 	maxPty := flag.Int("max-pty-sessions", envInt("ARKTIS_MAX_PTY", 4),
 		"Maximum simultaneous PTY sessions; further opens are rejected with reason=\"agent at pty capacity\"")
+	auditLogPath := flag.String("audit-log", os.Getenv("ARKTIS_AUDIT_LOG"),
+		"Path to a JSON-line audit log of every exec/pty event (file is opened with O_APPEND|O_CREAT, mode 0600). Empty disables auditing.")
+	auditIncludeCmd := flag.Bool("audit-log-include-command", envBool("ARKTIS_AUDIT_LOG_INCLUDE_COMMAND", false),
+		"Include the full command body in audit records. Default logs only a SHA-256 hash + byte count.")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -103,12 +108,22 @@ func main() {
 		log.Printf("Elevation enabled: backend-issued elevation_required=true commands will run via sudo")
 	}
 
+	auditLog, err := audit.Open(*auditLogPath, *auditIncludeCmd)
+	if err != nil {
+		log.Fatalf("Failed to open audit log: %v", err)
+	}
+	defer auditLog.Close()
+	if *auditLogPath != "" {
+		log.Printf("Audit log enabled at %s (include_command=%v)", *auditLogPath, *auditIncludeCmd)
+	}
+
 	// Create session manager and WebSocket client.
 	mgr := session.NewManager(session.Config{
 		ScriptsDir:     scriptsDir,
 		MaxExec:        *maxExec,
 		MaxPty:         *maxPty,
 		AllowElevation: *allowElevation,
+		Audit:          auditLog,
 	})
 	client := connection.NewClient(cfg, state, mgr)
 

--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -114,7 +114,10 @@ func main() {
 	}
 	defer auditLog.Close()
 	if *auditLogPath != "" {
-		log.Printf("Audit log enabled at %s (include_command=%v)", *auditLogPath, *auditIncludeCmd)
+		// %q quotes the operator-supplied path to keep gosec's G706
+		// log-injection rule happy and to prevent any newline/tab in
+		// a misconfigured path from breaking log lines.
+		log.Printf("Audit log enabled at %q (include_command=%v)", *auditLogPath, *auditIncludeCmd)
 	}
 
 	// Create session manager and WebSocket client.

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,0 +1,172 @@
+// Package audit writes one JSON line per exec / pty event to an
+// operator-configured append-only file. The format is intentionally
+// flat so operators can grep, jq, or ship it to a SIEM without a parser.
+//
+// Records are flushed under a mutex so concurrent handlers cannot
+// interleave bytes within a single line, and the file is opened with
+// O_APPEND so concurrent writers from the kernel are also line-atomic
+// up to PIPE_BUF.
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// Logger writes JSON-line audit records. Logger is safe for concurrent use.
+//
+// If Path is empty the constructor returns a Logger whose methods are
+// no-ops, which lets call sites omit `if a != nil` checks.
+type Logger struct {
+	mu             sync.Mutex
+	w              io.Writer // nil = disabled
+	closer         io.Closer // closed by Close; nil for stub loggers
+	includeCommand bool
+}
+
+// Open returns a Logger that writes to path with mode 0600 (O_APPEND|O_CREAT).
+// An empty path returns a no-op Logger.
+func Open(path string, includeCommand bool) (*Logger, error) {
+	if path == "" {
+		return &Logger{}, nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open audit log %s: %w", path, err)
+	}
+	return &Logger{w: f, closer: f, includeCommand: includeCommand}, nil
+}
+
+// Close flushes and closes the underlying file. Safe to call on a no-op
+// Logger.
+func (l *Logger) Close() error {
+	if l == nil || l.closer == nil {
+		return nil
+	}
+	return l.closer.Close()
+}
+
+// ExecRequest records that the agent received an exec command.
+type ExecRequest struct {
+	RequestID         string
+	Executor          string
+	ElevationRequired bool
+	TimeoutSeconds    int
+	Command           string // hashed unless Logger.includeCommand
+}
+
+// ExecResult records the outcome of an exec command.
+type ExecResult struct {
+	RequestID       string
+	ExitCode        int
+	DurationSeconds float64
+	StdoutBytes     int
+	StderrBytes     int
+	StdoutTruncated bool
+	StderrTruncated bool
+}
+
+// PtyOpen records the start of an interactive PTY session.
+type PtyOpen struct {
+	SessionID string
+	TermType  string
+	Cols      int
+	Rows      int
+}
+
+// PtyClose records the end of an interactive PTY session.
+type PtyClose struct {
+	SessionID string
+	Reason    string
+}
+
+// LogExecRequest writes an "exec_request" record.
+func (l *Logger) LogExecRequest(r ExecRequest) {
+	if l == nil || l.w == nil {
+		return
+	}
+	rec := map[string]interface{}{
+		"event":              "exec_request",
+		"request_id":         r.RequestID,
+		"executor":           r.Executor,
+		"elevation_required": r.ElevationRequired,
+		"timeout_seconds":    r.TimeoutSeconds,
+	}
+	if l.includeCommand {
+		rec["command"] = r.Command
+	} else {
+		rec["command_sha256"] = hashCmd(r.Command)
+		rec["command_bytes"] = len(r.Command)
+	}
+	l.write(rec)
+}
+
+// LogExecResult writes an "exec_result" record.
+func (l *Logger) LogExecResult(r ExecResult) {
+	if l == nil || l.w == nil {
+		return
+	}
+	l.write(map[string]interface{}{
+		"event":            "exec_result",
+		"request_id":       r.RequestID,
+		"exit_code":        r.ExitCode,
+		"duration_seconds": r.DurationSeconds,
+		"stdout_bytes":     r.StdoutBytes,
+		"stderr_bytes":     r.StderrBytes,
+		"stdout_truncated": r.StdoutTruncated,
+		"stderr_truncated": r.StderrTruncated,
+	})
+}
+
+// LogPtyOpen writes a "pty_open" record.
+func (l *Logger) LogPtyOpen(r PtyOpen) {
+	if l == nil || l.w == nil {
+		return
+	}
+	l.write(map[string]interface{}{
+		"event":      "pty_open",
+		"session_id": r.SessionID,
+		"term_type":  r.TermType,
+		"cols":       r.Cols,
+		"rows":       r.Rows,
+	})
+}
+
+// LogPtyClose writes a "pty_close" record.
+func (l *Logger) LogPtyClose(r PtyClose) {
+	if l == nil || l.w == nil {
+		return
+	}
+	l.write(map[string]interface{}{
+		"event":      "pty_close",
+		"session_id": r.SessionID,
+		"reason":     r.Reason,
+	})
+}
+
+func (l *Logger) write(rec map[string]interface{}) {
+	rec["ts"] = time.Now().UTC().Format(time.RFC3339Nano)
+	line, err := json.Marshal(rec)
+	if err != nil {
+		// Marshalling a map with primitives shouldn't fail; drop on error.
+		return
+	}
+	line = append(line, '\n')
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	// Best-effort write — the audit file might be on a noexec/full disk.
+	// We don't surface the error here because the caller is the request
+	// handler; logging would create a feedback loop with the audit log.
+	_, _ = l.w.Write(line)
+}
+
+func hashCmd(cmd string) string {
+	sum := sha256.Sum256([]byte(cmd))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,10 +32,16 @@ type Logger struct {
 
 // Open returns a Logger that writes to path with mode 0600 (O_APPEND|O_CREAT).
 // An empty path returns a no-op Logger.
+//
+// path is intentionally operator-controlled — it comes from the
+// --audit-log CLI flag (or ARKTIS_AUDIT_LOG) and the operator chooses
+// where the agent's audit trail lives. gosec's G304 file-inclusion
+// rule does not apply here.
 func Open(path string, includeCommand bool) (*Logger, error) {
 	if path == "" {
 		return &Logger{}, nil
 	}
+	// #nosec G304 -- path is the operator-supplied audit log location.
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open audit log %s: %w", path, err)

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,153 @@
+package audit
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func readLines(t *testing.T, path string) []map[string]interface{} {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var out []map[string]interface{}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		var rec map[string]interface{}
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			t.Fatalf("bad JSON line %q: %v", sc.Text(), err)
+		}
+		out = append(out, rec)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return out
+}
+
+func TestLoggerNoOpWhenPathEmpty(t *testing.T) {
+	t.Parallel()
+	l, err := Open("", false)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Should not panic / error even though there's no file.
+	l.LogExecRequest(ExecRequest{RequestID: "r1", Command: "x"})
+	l.LogExecResult(ExecResult{RequestID: "r1"})
+	l.LogPtyOpen(PtyOpen{SessionID: "s1"})
+	l.LogPtyClose(PtyClose{SessionID: "s1"})
+	if err := l.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestLoggerHashesCommandByDefault(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	l, err := Open(path, false /* includeCommand */)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	l.LogExecRequest(ExecRequest{RequestID: "req-1", Executor: "bash", Command: "secret stuff"})
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	lines := readLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(lines))
+	}
+	rec := lines[0]
+	if rec["event"] != "exec_request" {
+		t.Errorf("event = %v", rec["event"])
+	}
+	if rec["request_id"] != "req-1" {
+		t.Errorf("request_id = %v", rec["request_id"])
+	}
+	if _, present := rec["command"]; present {
+		t.Errorf("command should be hashed, not logged in cleartext")
+	}
+	if _, present := rec["command_sha256"]; !present {
+		t.Errorf("command_sha256 missing")
+	}
+	if rec["command_bytes"].(float64) != float64(len("secret stuff")) {
+		t.Errorf("command_bytes = %v", rec["command_bytes"])
+	}
+}
+
+func TestLoggerIncludesCommandWhenAsked(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	l, err := Open(path, true /* includeCommand */)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	l.LogExecRequest(ExecRequest{RequestID: "r2", Command: "echo hi"})
+	_ = l.Close()
+
+	lines := readLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(lines))
+	}
+	if lines[0]["command"] != "echo hi" {
+		t.Errorf("command = %v", lines[0]["command"])
+	}
+}
+
+func TestLoggerFilePermissions(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	l, err := Open(path, false)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer l.Close()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Mode().Perm() != 0o600 {
+		t.Errorf("audit log perm = %#o, want 0600", st.Mode().Perm())
+	}
+}
+
+func TestLoggerConcurrentLinesAreAtomic(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.log")
+	l, err := Open(path, true)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	const n = 200
+	cmd := strings.Repeat("X", 1024) // big enough that interleaving would break JSON
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			l.LogExecRequest(ExecRequest{RequestID: "r", Command: cmd})
+		}(i)
+	}
+	wg.Wait()
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	lines := readLines(t, path)
+	if len(lines) != n {
+		t.Errorf("expected %d records, got %d (likely interleaving)", n, len(lines))
+	}
+}

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bisskar/arktis-agent/internal/config"
@@ -39,15 +40,41 @@ var ErrSendBufferFull = errors.New("send buffer full")
 // writer goroutine were ready, or after they wound down.
 var errNotConnected = errors.New("not connected")
 
+// errStaleConnection indicates a handler from a previous connection
+// generation tried to write after the agent had reconnected. The send
+// is dropped to avoid leaking a stale exec_result / pty_output onto the
+// new connection where the backend may have already given up on it.
+var errStaleConnection = errors.New("stale connection")
+
 // Client manages the WebSocket connection to the backend.
 type Client struct {
 	config  *config.Config
 	state   *config.State
 	manager *session.Manager
 
+	// gen is bumped on every connect() entry and again on closeConn so
+	// that any handler still holding a connSender from a previous
+	// connection observes the change and drops its writes.
+	gen atomic.Uint64
+
 	mu   sync.Mutex
 	conn *websocket.Conn  // active connection or nil
 	out  chan interface{} // active send queue or nil; drained by writer goroutine
+}
+
+// connSender is the per-connection Sender handed to handler goroutines.
+// It carries the generation number captured at the moment connect()
+// installed the queue, so a write from an outdated handler can be
+// rejected before it reaches the (possibly reused) write channel.
+type connSender struct {
+	c   *Client
+	gen uint64
+}
+
+// Send routes through the Client's gen-checked send path. Implements
+// session.Sender.
+func (s connSender) Send(msg interface{}) error {
+	return s.c.sendForGen(s.gen, msg)
 }
 
 // NewClient creates a new WebSocket client.
@@ -209,10 +236,16 @@ func (c *Client) connect(ctx context.Context) error {
 	// All post-handshake Send() calls go through this queue so a chatty PTY
 	// can no longer hold a single mutex and starve heartbeats / other sessions.
 	out := make(chan interface{}, sendBufSize)
+	myGen := c.gen.Add(1)
 	c.mu.Lock()
 	c.out = out
 	c.mu.Unlock()
 	defer func() {
+		// Bump gen so any in-flight handler holding a connSender for myGen
+		// observes a stale connection and drops its writes. This must
+		// happen before we tear the queue down so writes already past
+		// the gen check still see a live channel.
+		c.gen.Add(1)
 		c.mu.Lock()
 		if c.out == out {
 			c.out = nil
@@ -220,6 +253,8 @@ func (c *Client) connect(ctx context.Context) error {
 		c.mu.Unlock()
 		close(out)
 	}()
+
+	sender := connSender{c: c, gen: myGen}
 
 	writerDone := make(chan struct{})
 	go func() {
@@ -237,7 +272,7 @@ func (c *Client) connect(ctx context.Context) error {
 	defer hbCancel()
 	hbDone := make(chan struct{})
 	defer close(hbDone)
-	go c.heartbeatLoop(hbCtx, hbDone)
+	go c.heartbeatLoop(hbCtx, hbDone, sender)
 
 	// Close the websocket when the context is cancelled. This unblocks
 	// conn.ReadMessage() in the read loop so graceful shutdown doesn't
@@ -253,7 +288,7 @@ func (c *Client) connect(ctx context.Context) error {
 	defer close(closeOnCancelDone)
 
 	// Read loop blocks until error or context cancellation.
-	c.readLoop(ctx, conn)
+	c.readLoop(ctx, conn, sender)
 
 	return nil
 }
@@ -283,7 +318,12 @@ func (c *Client) writeLoop(ctx context.Context, conn *websocket.Conn, out <-chan
 }
 
 // readLoop reads and dispatches messages from the backend.
-func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn) {
+//
+// sender is the connSender stamped with this connection's generation;
+// handlers spawned here use it for their replies, so any write that
+// outlives this connection harmlessly errors out instead of landing on
+// the next one.
+func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn, sender connSender) {
 	defer c.closeConn()
 
 	for {
@@ -316,7 +356,7 @@ func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn) {
 				log.Printf("Failed to parse exec message: %v", err)
 				continue
 			}
-			go c.manager.HandleExec(ctx, &msg, c)
+			go c.manager.HandleExec(ctx, &msg, sender)
 
 		case "pty_open":
 			var msg protocol.PtyOpenMessage
@@ -324,7 +364,7 @@ func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn) {
 				log.Printf("Failed to parse pty_open message: %v", err)
 				continue
 			}
-			go c.manager.HandlePtyOpen(&msg, c)
+			go c.manager.HandlePtyOpen(&msg, sender)
 
 		case "pty_input":
 			var msg protocol.PtyInputMessage
@@ -360,10 +400,10 @@ func (c *Client) readLoop(ctx context.Context, conn *websocket.Conn) {
 	}
 }
 
-// heartbeatLoop sends heartbeat messages at regular intervals.
-// done is closed by the connect() call frame to terminate the loop on
-// disconnect; ctx covers root-shutdown.
-func (c *Client) heartbeatLoop(ctx context.Context, done <-chan struct{}) {
+// heartbeatLoop sends heartbeat messages at regular intervals through
+// the per-connection sender. done is closed by the connect() call frame
+// to terminate the loop on disconnect; ctx covers root-shutdown.
+func (c *Client) heartbeatLoop(ctx context.Context, done <-chan struct{}, sender connSender) {
 	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 
@@ -374,7 +414,7 @@ func (c *Client) heartbeatLoop(ctx context.Context, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			if err := c.Send(protocol.HeartbeatMessage{Type: "heartbeat"}); err != nil {
+			if err := sender.Send(protocol.HeartbeatMessage{Type: "heartbeat"}); err != nil {
 				log.Printf("Failed to enqueue heartbeat: %v", err)
 				// Don't return on a backpressure-only failure — we'll
 				// try again next tick. A genuine teardown is signalled
@@ -387,11 +427,18 @@ func (c *Client) heartbeatLoop(ctx context.Context, done <-chan struct{}) {
 	}
 }
 
-// Send enqueues msg onto the writer goroutine's queue. It is non-blocking:
-// if the queue is full it returns ErrSendBufferFull immediately so a
-// misbehaving sender (e.g. a chatty PTY) can never starve other senders
-// or hold a write mutex across slow network frames.
-func (c *Client) Send(msg interface{}) error {
+// sendForGen enqueues msg onto the writer goroutine's queue, but only
+// if gen still matches the current connection generation. A handler
+// holding a sender from a previous connection will see ErrStaleConnection
+// and drop the write rather than land it on the new connection.
+//
+// Like Send before it, this is non-blocking: when the queue is full it
+// returns ErrSendBufferFull immediately so a misbehaving producer (e.g.
+// a chatty PTY) can never starve other senders.
+func (c *Client) sendForGen(gen uint64, msg interface{}) error {
+	if c.gen.Load() != gen {
+		return errStaleConnection
+	}
 	c.mu.Lock()
 	out := c.out
 	c.mu.Unlock()

--- a/internal/executor/command_test.go
+++ b/internal/executor/command_test.go
@@ -1,0 +1,77 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("under cap", func(t *testing.T) {
+		t.Parallel()
+		got, truncated := truncate("hello", 100)
+		if truncated {
+			t.Errorf("did not expect truncation")
+		}
+		if got != "hello" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("at cap", func(t *testing.T) {
+		t.Parallel()
+		s := strings.Repeat("a", 10)
+		got, truncated := truncate(s, 10)
+		if truncated {
+			t.Errorf("did not expect truncation at exact cap")
+		}
+		if got != s {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("over cap", func(t *testing.T) {
+		t.Parallel()
+		s := strings.Repeat("a", 50)
+		got, truncated := truncate(s, 10)
+		if !truncated {
+			t.Errorf("expected truncation flag")
+		}
+		if !strings.HasPrefix(got, strings.Repeat("a", 10)) {
+			t.Errorf("expected prefix preserved: %q", got)
+		}
+		if !strings.Contains(got, "[OUTPUT TRUNCATED at 1MB]") {
+			t.Errorf("expected truncation marker, got %q", got)
+		}
+	})
+
+	// Slicing a multi-byte rune mid-byte produces invalid UTF-8 which
+	// the JSON encoder later replaces with U+FFFD. truncate must back
+	// up to the previous rune boundary so the result stays valid.
+	t.Run("rune boundary preserved", func(t *testing.T) {
+		t.Parallel()
+		// Each rune is 3 bytes in UTF-8.
+		s := strings.Repeat("世", 20) // 60 bytes
+		// Cut mid-rune: byte index 10 is in the middle of the 4th rune.
+		got, truncated := truncate(s, 10)
+		if !truncated {
+			t.Fatalf("expected truncation")
+		}
+		// The prefix portion of `got` (before the truncation marker) must
+		// be valid UTF-8.
+		marker := "\n[OUTPUT TRUNCATED at 1MB]"
+		prefix := strings.TrimSuffix(got, marker)
+		if !utf8.ValidString(prefix) {
+			t.Errorf("truncated prefix is not valid UTF-8: %q", prefix)
+		}
+		// The prefix length must be at most maxBytes and a multiple of 3.
+		if len(prefix) > 10 {
+			t.Errorf("prefix exceeds cap: %d bytes", len(prefix))
+		}
+		if len(prefix)%3 != 0 {
+			t.Errorf("prefix should land on rune boundary; got %d bytes", len(prefix))
+		}
+	})
+}

--- a/internal/executor/pty_size_test.go
+++ b/internal/executor/pty_size_test.go
@@ -1,0 +1,29 @@
+package executor
+
+import "testing"
+
+func TestSanitizePtySize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		cols, rows         int
+		wantCols, wantRows uint16
+		why                string
+	}{
+		{80, 24, 80, 24, "normal"},
+		{0, 0, defaultPtyCols, defaultPtyRows, "zero falls back to defaults"},
+		{-1, -1, defaultPtyCols, defaultPtyRows, "negative falls back"},
+		{1, 1, 1, 1, "minimum 1x1 preserved"},
+		{maxPtyDim, maxPtyDim, maxPtyDim, maxPtyDim, "uint16 max preserved"},
+		{maxPtyDim + 1, maxPtyDim + 1, maxPtyDim, maxPtyDim, "above uint16 max clamped"},
+		{1_000_000, 999, maxPtyDim, 999, "huge cols clamped, rows preserved"},
+	}
+
+	for _, c := range cases {
+		gotC, gotR := sanitizePtySize(c.cols, c.rows)
+		if gotC != c.wantCols || gotR != c.wantRows {
+			t.Errorf("sanitizePtySize(%d,%d) = (%d,%d), want (%d,%d) (%s)",
+				c.cols, c.rows, gotC, gotR, c.wantCols, c.wantRows, c.why)
+		}
+	}
+}

--- a/internal/executor/shell_linux.go
+++ b/internal/executor/shell_linux.go
@@ -31,6 +31,7 @@ func resolveLinuxShell() string {
 		if path, ok := validateShell(v); ok {
 			return path
 		}
+		// #nosec G706 -- $SHELL is operator-supplied env input, not network; %q quotes it.
 		log.Printf("Warning: $SHELL %q failed validation; falling back to shell allowlist", v)
 	}
 	for _, c := range linuxShellAllowlist {

--- a/internal/executor/term_test.go
+++ b/internal/executor/term_test.go
@@ -1,0 +1,32 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeTerm(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+		why      string
+	}{
+		{"", defaultTerm, "empty falls back to default"},
+		{"xterm", "xterm", "plain term ok"},
+		{"xterm-256color", "xterm-256color", "with hyphen ok"},
+		{"screen.linux", "screen.linux", "with dot ok"},
+		{"foo_bar", "foo_bar", "with underscore ok"},
+		{strings.Repeat("a", 64), strings.Repeat("a", 64), "max length 64 ok"},
+		{strings.Repeat("a", 65), defaultTerm, "65 chars falls back"},
+		{"xterm space", defaultTerm, "space rejected"},
+		{"xterm\necho", defaultTerm, "newline injection rejected"},
+		{"xterm\x00", defaultTerm, "NUL rejected"},
+		{"$(rm -rf /)", defaultTerm, "shell metacharacters rejected"},
+	}
+	for _, c := range cases {
+		if got := sanitizeTerm(c.in); got != c.want {
+			t.Errorf("sanitizeTerm(%q) = %q, want %q (%s)", c.in, got, c.want, c.why)
+		}
+	}
+}

--- a/internal/session/ids_test.go
+++ b/internal/session/ids_test.go
@@ -1,0 +1,70 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want bool
+		why  string
+	}{
+		{"abc", true, "alphanum"},
+		{"ABC123", true, "mixed case + digits"},
+		{"some_id-42", true, "underscore + hyphen allowed"},
+		{strings.Repeat("a", 64), true, "max length 64 ok"},
+		{"", false, "empty rejected"},
+		{strings.Repeat("a", 65), false, "65 chars rejected"},
+		{"abc.def", false, "dot not allowed"},
+		{"abc def", false, "space not allowed"},
+		{"abc/def", false, "slash not allowed"},
+		{"abc\ndef", false, "newline not allowed (CRLF injection probe)"},
+		{"abc\x00def", false, "NUL not allowed"},
+		{"../etc/passwd", false, "path traversal probe"},
+		{"\r\nFAKE", false, "CRLF prefix"},
+	}
+
+	for _, c := range cases {
+		if got := validID(c.in); got != c.want {
+			t.Errorf("validID(%q) = %v, want %v (%s)", c.in, got, c.want, c.why)
+		}
+	}
+}
+
+func TestSanitizeOutput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"clean ascii", "clean ascii"},
+		{"line1\nline2", "line1\nline2"},
+		{"col1\tcol2", "col1\tcol2"},
+		{"hello\x00world", `hello\x00world`},
+		{"\x1b]0;evil\x07", `\x1b]0;evil\x07`},
+		{"\rOVERWRITE", `\x0dOVERWRITE`},
+		{"text\x7fwith DEL", `text\x7fwith DEL`},
+		{"\r\nFAKE LINE\r\n", `\x0d` + "\nFAKE LINE" + `\x0d` + "\n"},
+	}
+	for _, c := range cases {
+		if got := sanitizeOutput(c.in); got != c.want {
+			t.Errorf("sanitizeOutput(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSanitizeOutputIdempotent(t *testing.T) {
+	t.Parallel()
+
+	in := "step1\x1b[31m red \x1b[0m line\nstep2 \x07 bell"
+	once := sanitizeOutput(in)
+	twice := sanitizeOutput(once)
+	if once != twice {
+		t.Errorf("sanitizeOutput not idempotent: once=%q twice=%q", once, twice)
+	}
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"sync"
 
+	"github.com/bisskar/arktis-agent/internal/audit"
 	"github.com/bisskar/arktis-agent/internal/executor"
 	"github.com/bisskar/arktis-agent/internal/protocol"
 )
@@ -30,6 +31,7 @@ type Config struct {
 	MaxExec        int
 	MaxPty         int
 	AllowElevation bool
+	Audit          *audit.Logger // nil-safe; methods no-op when unset
 }
 
 // Manager tracks concurrent command executions and PTY sessions and
@@ -40,6 +42,7 @@ type Manager struct {
 	allowElevation bool
 	execSem        chan struct{}
 	ptySem         chan struct{}
+	audit          *audit.Logger
 
 	ptySessions sync.Map // sessionID -> *executor.PtySession
 }
@@ -57,6 +60,7 @@ func NewManager(cfg Config) *Manager {
 		allowElevation: cfg.AllowElevation,
 		execSem:        make(chan struct{}, cfg.MaxExec),
 		ptySem:         make(chan struct{}, cfg.MaxPty),
+		audit:          cfg.Audit,
 	}
 }
 
@@ -108,6 +112,14 @@ func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sen
 		log.Printf("Executing command (request_id=%q, executor=%q)", msg.RequestID, msg.ExecutorName)
 	}
 
+	m.audit.LogExecRequest(audit.ExecRequest{
+		RequestID:         msg.RequestID,
+		Executor:          msg.ExecutorName,
+		ElevationRequired: msg.ElevationRequired,
+		TimeoutSeconds:    msg.TimeoutSeconds,
+		Command:           msg.Command,
+	})
+
 	res, err := executor.ExecuteCommand(executor.ExecRequest{
 		Ctx:                ctx,
 		ScriptsDir:         m.scriptsDir,
@@ -133,6 +145,16 @@ func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sen
 		ExitCode:        res.ExitCode,
 		DurationSeconds: res.DurationSeconds,
 	}
+
+	m.audit.LogExecResult(audit.ExecResult{
+		RequestID:       msg.RequestID,
+		ExitCode:        res.ExitCode,
+		DurationSeconds: res.DurationSeconds,
+		StdoutBytes:     len(res.Stdout),
+		StderrBytes:     len(res.Stderr),
+		StdoutTruncated: res.StdoutTruncated,
+		StderrTruncated: res.StderrTruncated,
+	})
 
 	if err := sender.Send(out); err != nil {
 		log.Printf("Failed to send exec result (request_id=%q): %v", msg.RequestID, err)
@@ -185,6 +207,12 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 	}
 
 	log.Printf("Opening PTY session_id=%q (term=%q, %dx%d)", msg.SessionID, msg.TermType, msg.Cols, msg.Rows)
+	m.audit.LogPtyOpen(audit.PtyOpen{
+		SessionID: msg.SessionID,
+		TermType:  msg.TermType,
+		Cols:      msg.Cols,
+		Rows:      msg.Rows,
+	})
 
 	session, err := executor.NewPtySession(msg.SessionID, msg.TermType, msg.Cols, msg.Rows)
 	if err != nil {
@@ -232,6 +260,7 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 		Reason:    "session ended",
 	})
 
+	m.audit.LogPtyClose(audit.PtyClose{SessionID: msg.SessionID, Reason: "session ended"})
 	log.Printf("PTY session_id=%q closed", msg.SessionID)
 }
 


### PR DESCRIPTION
## Summary

Sixth batch — tests, reliability, audit logging, supply-chain hardening:

- **#30** — bootstrap unit tests covering the validators/sanitisers added by earlier PRs (`validID`, `sanitizeOutput`, `sanitizeTerm`, `sanitizePtySize`, `truncate`). `make test` now runs `go test -race ./...` so future PRs aren't a no-op gate.
- **#34** — each `connect()` captures a generation via `atomic.Uint64`. Handlers receive a `connSender` carrying that generation; `Send()` short-circuits with `errStaleConnection` when the generation has moved on (`closeConn` or a fresh `connect`). A handler that finishes after a reconnect can no longer leak its reply onto the new connection. Heartbeats and post-handshake writes also use the same per-connection sender.
- **#18** — new `internal/audit` package writes one JSON line per `exec_request` / `exec_result` / `pty_open` / `pty_close` to a `--audit-log` path (env: `ARKTIS_AUDIT_LOG`). The file is opened with `O_APPEND|O_CREAT` mode `0600`. Commands are hashed by default; `--audit-log-include-command` opts into full-text logging. Empty path returns a no-op logger so call sites stay branch-free. Tests cover: no-op-when-disabled, hash-by-default, include-when-asked, file mode `0600`, line atomicity under 200 concurrent writers.
- **#10** — `release.yml` computes `sha256sums.txt` of every artifact and signs each artifact (and the manifest) with `cosign` keyless OIDC. README install snippets now download the manifest, verify its `cosign` signature against the GitHub OIDC identity, then verify the binary's hash before `chmod +x`.

## Test plan

- [x] `go build ./...` clean on `linux`
- [x] `go vet ./...` clean on `linux`
- [x] `GOOS=windows go build ./...` clean
- [x] `GOOS=windows go vet ./...` clean
- [x] `go test -race ./...` passes (audit, executor, session)
- [x] `gofmt -l` clean on touched files
- [ ] Manual: tag `v0.1.3-test`, push tag; verify the release contains `sha256sums.txt`, `*.cosign.bundle`, `*.sig`, `*.crt` files
- [ ] Manual: `cosign verify-blob --bundle sha256sums.txt.cosign.bundle …` succeeds against the OIDC identity
- [ ] Manual: run agent with `--audit-log /tmp/a.log`, run an exec, observe paired `exec_request` and `exec_result` JSONL records
- [ ] Manual: simulate a reconnect mid-exec and verify the stale handler's `Send()` returns `stale connection`, not landing on the new connection

https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz)_