### PR TITLE
fix: least privilege, replay protection, DNS-rebind + TLS pinning, v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       # via the SARIF upload below.
       - name: Run gosec
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
           gosec -fmt sarif -out gosec.sarif -no-fail -exclude-dir=.github ./...
 
       - name: Upload SARIF

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.0
+VERSION := 0.2.0
 LDFLAGS := -ldflags "-X main.Version=$(VERSION) -s -w"
 DIST := dist
 

--- a/README.md
+++ b/README.md
@@ -78,20 +78,45 @@ The agent self-registers on first connect. It will appear in your Lab Hosts list
 
 ### 3. Run as a Service (Optional)
 
-**Linux (systemd):**
+The agent does **not** need root / SYSTEM to run non-elevated tests. The
+recommended setup runs the agent as a dedicated low-privilege user and
+opts elevation in only when you actually need atomics that ship
+`elevation_required=true`.
+
+**Linux (systemd, least privilege — recommended):**
 
 ```bash
-sudo tee /etc/systemd/system/arktis-agent.service > /dev/null <<EOF
+# 1. Create a dedicated user + state directory.
+sudo useradd --system --home-dir /var/lib/arktis-agent --shell /usr/sbin/nologin arktis
+sudo install -d -o arktis -g arktis -m 0700 /var/lib/arktis-agent
+
+# 2. Install the verified binary as root, run as `arktis`.
+sudo install -o root -g root -m 0755 arktis-agent /usr/local/bin/arktis-agent
+
+sudo tee /etc/systemd/system/arktis-agent.service > /dev/null <<'EOF'
 [Unit]
 Description=Arktis Agent
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/arktis-agent --url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>
+User=arktis
+Group=arktis
+ExecStart=/usr/local/bin/arktis-agent \
+  --url wss://your-server.com/api/v1/agent/ws \
+  --key <YOUR_KEY> \
+  --state-dir /var/lib/arktis-agent \
+  --require-non-root \
+  --audit-log /var/lib/arktis-agent/audit.log
 Restart=always
 RestartSec=5
-User=root
+
+# Standard hardening — fail closed on anything the agent doesn't need.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/var/lib/arktis-agent
 
 [Install]
 WantedBy=multi-user.target
@@ -101,16 +126,49 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now arktis-agent
 ```
 
-**Windows (as a scheduled task):**
+`--require-non-root` makes the agent fail fast if it ever finds itself
+running as `euid=0`, so a misconfigured unit can't quietly grant the
+backend root.
+
+**Linux ("Lab mode" — when you need elevation):**
+
+If your atomics include tests that require `sudo` (e.g. process
+injection, kernel-module load), pass `--allow-elevation` and grant the
+`arktis` user a *minimal* sudoers entry scoped to the agent's staged
+scripts under `/var/lib/arktis-agent/scripts/`. Do not run the agent
+itself as root.
+
+```sudoers
+# /etc/sudoers.d/arktis
+arktis ALL=(root) NOPASSWD: /bin/bash /var/lib/arktis-agent/scripts/arktis-*.sh, \
+                              /bin/sh   /var/lib/arktis-agent/scripts/arktis-*.sh
+Defaults!/bin/bash, /bin/sh env_reset
+```
+
+**Windows (managed service account — recommended):**
+
+Create a low-privilege local account (or a domain-managed service
+account / gMSA) and register the scheduled task under it instead of
+SYSTEM. Grant the account write access to `%ProgramData%\arktis-agent`.
 
 ```powershell
-$action = New-ScheduledTaskAction -Execute "$env:ProgramFiles\arktis-agent.exe" `
-  -Argument "--url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY>"
-$trigger = New-ScheduledTaskTrigger -AtStartup
+# Replace with your account; use a gMSA in domain environments.
+$cred  = Get-Credential -UserName ".\arktis-svc" -Message "Service account password"
+
+$action   = New-ScheduledTaskAction -Execute "$env:ProgramFiles\arktis-agent.exe" `
+  -Argument "--url wss://your-server.com/api/v1/agent/ws --key <YOUR_KEY> --require-non-root"
+$trigger  = New-ScheduledTaskTrigger -AtStartup
 $settings = New-ScheduledTaskSettingsSet -RestartCount 999 -RestartInterval (New-TimeSpan -Seconds 30)
-Register-ScheduledTask -TaskName "ArktisAgent" -Action $action -Trigger $trigger `
-  -Settings $settings -User "SYSTEM" -RunLevel Highest
+
+Register-ScheduledTask -TaskName "ArktisAgent" `
+  -Action $action -Trigger $trigger -Settings $settings `
+  -User $cred.UserName -Password $cred.GetNetworkCredential().Password
 ```
+
+**Windows ("Lab mode"):** if you genuinely need SYSTEM (atomics that
+exercise kernel APIs), use `-User "SYSTEM" -RunLevel Highest` and
+`--allow-elevation` — but treat that host as fully owned by the
+backend.
 
 ## Features
 
@@ -146,16 +204,84 @@ Register-ScheduledTask -TaskName "ArktisAgent" -Action $action -Trigger $trigger
 | `--url` | `ARKTIS_URL` | (required) | Backend WebSocket URL |
 | `--key` | `ARKTIS_KEY` | (required) | Registration key from Arktis |
 | `--state-dir` | `ARKTIS_STATE_DIR` | `/etc/arktis-agent` (Linux) or `%ProgramData%\arktis-agent` (Windows) | Directory for persistent state |
+| `--require-non-root` | `ARKTIS_REQUIRE_NON_ROOT` | `false` | Refuse to start if running as root (Linux euid=0). Recommended for production. |
+| `--allow-elevation` | `ARKTIS_ALLOW_ELEVATION` | `false` | Honour `elevation_required=true` exec messages (otherwise: refuse with `exit_code=126`). |
+| `--max-exec-concurrency` | `ARKTIS_MAX_EXEC` | `8` | Max simultaneous in-flight exec commands. |
+| `--max-pty-sessions` | `ARKTIS_MAX_PTY` | `4` | Max simultaneous PTY sessions. |
+| `--audit-log` | `ARKTIS_AUDIT_LOG` | `` | Path to a JSON-line audit log of every exec/pty event. Empty disables auditing. |
+| `--audit-log-include-command` | `ARKTIS_AUDIT_LOG_INCLUDE_COMMAND` | `false` | Include the full command body in audit records (default logs only a SHA-256 + byte count). |
+| `--ca-cert` | `ARKTIS_CA_CERT` | (system) | Path to a PEM file used as the **only** trusted root for the backend's TLS cert. Defence-in-depth against system-CA compromise. |
+| `--pin-spki` | `ARKTIS_PIN_SPKI` | `` | Hex-encoded SHA-256 of the backend's SubjectPublicKeyInfo. The dial fails if the leaf cert's SPKI hash does not match. |
+| `--strict-endpoint` | `ARKTIS_STRICT_ENDPOINT` | `false` | After a successful first connect, refuse to reconnect if the backend's resolved IP changes (DNS-rebinding mitigation). |
 | `--version` | — | — | Print version and exit |
 
-## Security
+## Security Model
 
-- **Outbound only** — the agent initiates the connection. No inbound ports needed on the target host.
-- **Key-based authentication** — agents authenticate with a registration key (SHA-256 hashed server-side, never stored in plaintext).
-- **Key revocation** — revoking a key in Arktis immediately disconnects all agents using it.
-- **Per-agent revocation** — individual hosts can be deactivated without affecting other agents on the same key.
-- **TLS transport** — use `wss://` in production for encrypted communication.
-- **Org/workspace scoping** — each key is bound to one organization and optionally one workspace. Agents cannot execute commands for other tenants.
+The agent is a **remote command executor**: whoever controls the
+backend can run arbitrary commands on every connected host with the
+agent's process privileges. The trust assumptions, in order of
+strength:
+
+1. **Backend → agent**: trusted by design. Anything the backend sends
+   (an `exec` with arbitrary `command`, a `pty_open`) will run.
+2. **Agent → host**: the agent only has the privileges of the user it
+   runs as. **Run as a dedicated low-privilege user.** Root / SYSTEM
+   should be reserved for atomics that genuinely need it (see
+   "Lab mode" above).
+3. **Backend identity**: verified via system-CA TLS (`wss://`) and the
+   bearer key. Cert-pinning / message-signing is on the roadmap (#9).
+
+### What runs as root vs. the agent user
+
+| Path | Runs as |
+|------|---------|
+| Default `exec` (`elevation_required=false`) | The agent's own user |
+| `exec` with `elevation_required=true` and `--allow-elevation` set | `sudo` (Linux) / inherited token (Windows) |
+| Interactive PTY (`pty_open`) | The agent's own user |
+
+If the agent is **not** started with `--allow-elevation`, any
+`elevation_required=true` message is rejected with `exit_code=126`.
+
+### Hardening checklist for production deployments
+
+- [ ] Run as a dedicated user (`arktis` on Linux, `arktis-svc` or a
+      gMSA on Windows). Use `--require-non-root` to fail closed.
+- [ ] Verify release artifacts (`cosign verify-blob` against the
+      published signature bundle) before installing.
+- [ ] Use `wss://` for the backend URL, not `ws://`.
+- [ ] Enable the audit log (`--audit-log /var/lib/arktis-agent/audit.log`)
+      and ship it to a central SIEM.
+- [ ] Set `--max-exec-concurrency` and `--max-pty-sessions` consistent
+      with the host's capacity.
+- [ ] Apply the sudoers fragment above instead of granting blanket
+      `NOPASSWD: ALL` if you need elevation.
+- [ ] Rotate the registration key on operator off-boarding.
+
+### Built-in defences
+
+- **Outbound only** — the agent initiates the connection. No inbound
+  ports needed on the target host.
+- **Key-based authentication** — agents authenticate with a
+  registration key (SHA-256 hashed server-side, never stored in
+  plaintext).
+- **Key revocation** — revoking a key in Arktis immediately
+  disconnects all agents using it.
+- **Per-agent revocation** — individual hosts can be deactivated
+  without affecting other agents on the same key.
+- **TLS transport** — use `wss://` in production for encrypted
+  communication.
+- **Org/workspace scoping** — each key is bound to one organization
+  and optionally one workspace. Agents cannot execute commands for
+  other tenants.
+- **Capacity caps** — `--max-exec-concurrency` and
+  `--max-pty-sessions` (defaults 8 and 4) bound the resources a
+  misbehaving / compromised backend can consume.
+- **Stripped child env** — spawned shells receive a minimal
+  whitelisted env; `ARKTIS_KEY`, `AWS_*`, `LD_PRELOAD`, etc. are
+  never inherited.
+- **Sanitised result fields** — `stdout_safe` / `stderr_safe`
+  carry an escape-stripped variant of process output for
+  log/SIEM ingestion that is sensitive to control bytes.
 
 ## Building from Source
 

--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -48,6 +48,14 @@ func main() {
 		"Path to a JSON-line audit log of every exec/pty event (file is opened with O_APPEND|O_CREAT, mode 0600). Empty disables auditing.")
 	auditIncludeCmd := flag.Bool("audit-log-include-command", envBool("ARKTIS_AUDIT_LOG_INCLUDE_COMMAND", false),
 		"Include the full command body in audit records. Default logs only a SHA-256 hash + byte count.")
+	requireNonRoot := flag.Bool("require-non-root", envBool("ARKTIS_REQUIRE_NON_ROOT", false),
+		"Refuse to start if the agent is running as root (Linux euid=0). Combine with --allow-elevation=false (the default) to enforce least privilege.")
+	caCertPath := flag.String("ca-cert", os.Getenv("ARKTIS_CA_CERT"),
+		"Path to a PEM file used as the *only* trusted root for the backend's TLS cert. Defence-in-depth against system-CA compromise.")
+	pinSPKI := flag.String("pin-spki", os.Getenv("ARKTIS_PIN_SPKI"),
+		"Hex-encoded SHA-256 of the backend's SubjectPublicKeyInfo. The dial fails if the leaf cert's SPKI hash does not match.")
+	strictEndpoint := flag.Bool("strict-endpoint", envBool("ARKTIS_STRICT_ENDPOINT", false),
+		"Refuse to reconnect if the backend's resolved IP differs from the one captured on first connect (DNS-rebinding mitigation).")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -63,9 +71,12 @@ func main() {
 	}
 
 	cfg := &config.Config{
-		BackendURL: *url,
-		Key:        *key,
-		StateDir:   *stateDir,
+		BackendURL:     *url,
+		Key:            *key,
+		StateDir:       *stateDir,
+		CACertPath:     *caCertPath,
+		PinSPKI:        *pinSPKI,
+		StrictEndpoint: *strictEndpoint,
 	}
 
 	// Ensure state directory exists.
@@ -100,6 +111,19 @@ func main() {
 	}
 
 	log.Printf("arktis-agent %s starting (state-dir=%s)", Version, cfg.StateDir)
+
+	// Least-privilege gate. os.Geteuid() returns -1 on Windows, so the
+	// numerical check naturally only applies on Unix.
+	euid := os.Geteuid()
+	if *requireNonRoot && euid == 0 {
+		log.Fatalf("--require-non-root set but agent is running as root (euid=0); " +
+			"create a dedicated user (see README 'Security Model')")
+	}
+	if euid == 0 && !*allowElevation {
+		log.Println("Warning: running as root without --allow-elevation. " +
+			"The agent does not need root privileges to run non-elevated tests. " +
+			"See README 'Security Model' for least-privilege setup.")
+	}
 
 	// Inject version into the connection package for registration messages.
 	connection.SetVersion(Version)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,15 +9,19 @@ import (
 
 // Config holds runtime configuration parsed from CLI flags.
 type Config struct {
-	BackendURL string
-	Key        string
-	StateDir   string
+	BackendURL     string
+	Key            string
+	StateDir       string
+	CACertPath     string // PEM file used as the *only* trusted root; empty = system roots
+	PinSPKI        string // hex SHA-256 of expected leaf SubjectPublicKeyInfo; empty = unpinned
+	StrictEndpoint bool   // refuse to reconnect to a different IP than last seen (#31)
 }
 
 // State holds persistent agent state across restarts.
 type State struct {
-	HostID       string `json:"host_id"`
-	RegisteredAt string `json:"registered_at"`
+	HostID        string `json:"host_id"`
+	RegisteredAt  string `json:"registered_at"`
+	LastBackendIP string `json:"last_backend_ip,omitempty"`
 }
 
 const stateFileName = "state.json"

--- a/internal/connection/tls_test.go
+++ b/internal/connection/tls_test.go
@@ -1,0 +1,61 @@
+package connection
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// makeSelfSignedCert returns an ECDSA self-signed cert for "127.0.0.1".
+func makeSelfSignedCert(t *testing.T) *x509.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return cert
+}
+
+func TestSPKIHashStable(t *testing.T) {
+	t.Parallel()
+	cert := makeSelfSignedCert(t)
+	got1 := spkiHash(cert)
+	got2 := spkiHash(cert)
+	if got1 != got2 {
+		t.Errorf("SPKI hash not stable: %s vs %s", got1, got2)
+	}
+	expected := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	if got1 != hex.EncodeToString(expected[:]) {
+		t.Errorf("SPKI hash does not match SHA-256 of SubjectPublicKeyInfo")
+	}
+}
+
+func TestSPKIHashDiffersAcrossKeys(t *testing.T) {
+	t.Parallel()
+	a := makeSelfSignedCert(t)
+	b := makeSelfSignedCert(t)
+	if spkiHash(a) == spkiHash(b) {
+		t.Errorf("two distinct keys produced the same SPKI hash")
+	}
+}

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -2,12 +2,18 @@ package connection
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -137,12 +143,41 @@ func (c *Client) connect(ctx context.Context) error {
 
 	log.Printf("Connecting to %s...", c.config.BackendURL)
 
+	tlsCfg, err := c.buildTLSConfig()
+	if err != nil {
+		return fmt.Errorf("build tls config: %w", err)
+	}
+
 	dialer := websocket.Dialer{
 		HandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:  tlsCfg,
 	}
 	conn, _, err := dialer.DialContext(ctx, c.config.BackendURL, header)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
+	}
+
+	// DNS-rebinding mitigation: compare the freshly-resolved peer IP
+	// against what we recorded the first time we connected. Mismatches
+	// always log a warning; --strict-endpoint additionally refuses the
+	// connection so an operator must explicitly clear the pin before the
+	// agent will follow the hostname to a new IP.
+	if peerIP := remoteIP(conn); peerIP != "" {
+		if c.state.LastBackendIP != "" && c.state.LastBackendIP != peerIP {
+			if c.config.StrictEndpoint {
+				_ = conn.Close()
+				return fmt.Errorf("backend IP changed (was %s, now %s); refusing under --strict-endpoint",
+					c.state.LastBackendIP, peerIP)
+			}
+			log.Printf("Warning: backend IP changed (was %s, now %s); --strict-endpoint not set",
+				c.state.LastBackendIP, peerIP)
+		}
+		if c.state.LastBackendIP != peerIP {
+			c.state.LastBackendIP = peerIP
+			if err := config.SaveState(c.config.StateDir, c.state); err != nil {
+				log.Printf("Warning: failed to persist backend IP: %v", err)
+			}
+		}
 	}
 
 	c.mu.Lock()
@@ -478,6 +513,88 @@ func writeJSON(conn *websocket.Conn, msg interface{}) error {
 		return fmt.Errorf("set write deadline: %w", err)
 	}
 	return conn.WriteJSON(msg)
+}
+
+// buildTLSConfig builds the *tls.Config the WebSocket dialer will use.
+//
+// Two operator-controlled defences-in-depth on top of system-CA trust:
+//   - --ca-cert: replaces the system root pool with a single PEM file,
+//     so a malicious CA in /etc/ssl/certs cannot mint an impersonating
+//     cert for the backend.
+//   - --pin-spki: a hex SHA-256 of the leaf cert's SubjectPublicKeyInfo.
+//     Any cert with a different public key is rejected even if it
+//     chains to a trusted root.
+//
+// Both are independent and may be combined. Returns nil if neither is
+// set, in which case gorilla/websocket falls back to its default TLS
+// behaviour (system CAs, hostname verification).
+func (c *Client) buildTLSConfig() (*tls.Config, error) {
+	if c.config.CACertPath == "" && c.config.PinSPKI == "" {
+		return nil, nil
+	}
+
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if c.config.CACertPath != "" {
+		// #nosec G304 -- path is the operator-supplied --ca-cert flag value.
+		pem, err := os.ReadFile(c.config.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("read --ca-cert %s: %w", c.config.CACertPath, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("--ca-cert %s contained no usable PEM certificates", c.config.CACertPath)
+		}
+		cfg.RootCAs = pool
+	}
+
+	if c.config.PinSPKI != "" {
+		want := strings.ToLower(strings.TrimSpace(c.config.PinSPKI))
+		want = strings.TrimPrefix(want, "sha256:")
+		if _, err := hex.DecodeString(want); err != nil || len(want) != 64 {
+			return nil, fmt.Errorf("--pin-spki must be a 64-character hex SHA-256, got %q", c.config.PinSPKI)
+		}
+		cfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return errors.New("tls: no peer certificate")
+			}
+			leaf, err := x509.ParseCertificate(rawCerts[0])
+			if err != nil {
+				return fmt.Errorf("tls: parse leaf cert: %w", err)
+			}
+			got := spkiHash(leaf)
+			if got != want {
+				return fmt.Errorf("tls: SPKI pin mismatch (got %s, want %s)", got, want)
+			}
+			return nil
+		}
+	}
+
+	return cfg, nil
+}
+
+// spkiHash returns the lowercase hex SHA-256 of cert's
+// SubjectPublicKeyInfo. Useful both for cosign-style pinning and for
+// surfacing the value in operator logs.
+func spkiHash(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	return hex.EncodeToString(sum[:])
+}
+
+// remoteIP extracts the host part of the WebSocket peer address, dropping
+// the port. Returns "" if the address can't be parsed (e.g. unix socket).
+func remoteIP(conn *websocket.Conn) string {
+	addr := conn.RemoteAddr()
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return ""
+	}
+	return host
 }
 
 // getVersion returns the agent version (set via ldflags in main).

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -570,6 +570,25 @@ func (c *Client) buildTLSConfig() (*tls.Config, error) {
 			}
 			return nil
 		}
+		// VerifyPeerCertificate is only invoked on a fresh handshake;
+		// resumed sessions skip it and could land us on a cert with the
+		// wrong public key. VerifyConnection runs on every handshake
+		// (initial and resumed), so we mirror the pin check there as a
+		// belt-and-suspenders gate. We also disable session resumption
+		// outright so that pinning is enforced via the primary path,
+		// not relying on TLS-stack-internal nuance.
+		cfg.VerifyConnection = func(cs tls.ConnectionState) error {
+			if len(cs.PeerCertificates) == 0 {
+				return errors.New("tls: no peer certificate on resumed connection")
+			}
+			got := spkiHash(cs.PeerCertificates[0])
+			if got != want {
+				return fmt.Errorf("tls: SPKI pin mismatch on resumed connection (got %s, want %s)", got, want)
+			}
+			return nil
+		}
+		cfg.SessionTicketsDisabled = true
+		cfg.ClientSessionCache = nil
 	}
 
 	return cfg, nil

--- a/internal/executor/shell_linux.go
+++ b/internal/executor/shell_linux.go
@@ -88,7 +88,8 @@ func NewPtySession(sessionID string, termType string, cols int, rows int) (*PtyS
 	}
 
 	colsU, rowsU := sanitizePtySize(cols, rows)
-	pty.Setsize(ptmx, &pty.Winsize{Cols: colsU, Rows: rowsU})
+	// Initial winsize is best-effort; the shell will pick up SIGWINCH if it fails.
+	_ = pty.Setsize(ptmx, &pty.Winsize{Cols: colsU, Rows: rowsU})
 
 	return &PtySession{
 		sessionID: sessionID,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/bisskar/arktis-agent/internal/audit"
 	"github.com/bisskar/arktis-agent/internal/executor"
@@ -19,8 +20,10 @@ type Sender interface {
 
 // Default capacity caps. Operators can override via Config.
 const (
-	defaultMaxExec = 8
-	defaultMaxPty  = 4
+	defaultMaxExec  = 8
+	defaultMaxPty   = 4
+	replayCacheSize = 1024
+	replayWindow    = 10 * time.Minute
 )
 
 // Config bundles operator-tunable knobs that flow from main into the
@@ -36,13 +39,16 @@ type Config struct {
 
 // Manager tracks concurrent command executions and PTY sessions and
 // enforces the agent's local policy: capacity limits (#16), duplicate
-// session_id rejection (#12), and the elevation opt-in gate (#6).
+// session_id rejection (#12), the elevation opt-in gate (#6), and
+// replay protection (#15).
 type Manager struct {
 	scriptsDir     string
 	allowElevation bool
 	execSem        chan struct{}
 	ptySem         chan struct{}
 	audit          *audit.Logger
+	execReplay     *Tracker
+	ptyReplay      *Tracker
 
 	ptySessions sync.Map // sessionID -> *executor.PtySession
 }
@@ -61,6 +67,8 @@ func NewManager(cfg Config) *Manager {
 		execSem:        make(chan struct{}, cfg.MaxExec),
 		ptySem:         make(chan struct{}, cfg.MaxPty),
 		audit:          cfg.Audit,
+		execReplay:     NewTracker(replayCacheSize, replayWindow),
+		ptyReplay:      NewTracker(replayCacheSize, replayWindow),
 	}
 }
 
@@ -74,6 +82,22 @@ func NewManager(cfg Config) *Manager {
 func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sender Sender) {
 	if !validID(msg.RequestID) {
 		log.Printf("Rejecting exec with invalid request_id %q", msg.RequestID)
+		return
+	}
+
+	// Replay gate: a captured exec frame can be replayed indefinitely
+	// without per-message signing (#9). Until then, reject any
+	// request_id seen within replayWindow with a structured 409.
+	if m.execReplay.Seen(msg.RequestID) {
+		log.Printf("Rejecting replayed exec request_id=%q", msg.RequestID)
+		const reason = "replayed request_id"
+		sender.Send(protocol.ExecResultMessage{
+			Type:       "exec_result",
+			RequestID:  msg.RequestID,
+			Stderr:     reason,
+			StderrSafe: reason,
+			ExitCode:   409,
+		})
 		return
 	}
 
@@ -175,6 +199,17 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "invalid session_id",
+		})
+		return
+	}
+
+	// Replay gate: same rationale as HandleExec.
+	if m.ptyReplay.Seen(msg.SessionID) {
+		log.Printf("Rejecting replayed pty_open session_id=%q", msg.SessionID)
+		sender.Send(protocol.PtyClosedMessage{
+			Type:      "pty_closed",
+			SessionID: msg.SessionID,
+			Reason:    "replayed session_id",
 		})
 		return
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -91,7 +91,7 @@ func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sen
 	if m.execReplay.Seen(msg.RequestID) {
 		log.Printf("Rejecting replayed exec request_id=%q", msg.RequestID)
 		const reason = "replayed request_id"
-		sender.Send(protocol.ExecResultMessage{
+		_ = sender.Send(protocol.ExecResultMessage{
 			Type:       "exec_result",
 			RequestID:  msg.RequestID,
 			Stderr:     reason,
@@ -107,7 +107,7 @@ func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sen
 		defer func() { <-m.execSem }()
 	default:
 		log.Printf("Rejecting exec request_id=%q: agent at exec capacity", msg.RequestID)
-		sender.Send(protocol.ExecResultMessage{
+		_ = sender.Send(protocol.ExecResultMessage{
 			Type:       "exec_result",
 			RequestID:  msg.RequestID,
 			Stderr:     "agent at exec capacity, retry later",
@@ -121,7 +121,7 @@ func (m *Manager) HandleExec(ctx context.Context, msg *protocol.ExecMessage, sen
 	if msg.ElevationRequired && !m.allowElevation {
 		log.Printf("Rejecting elevated exec request_id=%q: --allow-elevation not set", msg.RequestID)
 		const reason = "elevation refused: agent started without --allow-elevation"
-		sender.Send(protocol.ExecResultMessage{
+		_ = sender.Send(protocol.ExecResultMessage{
 			Type:       "exec_result",
 			RequestID:  msg.RequestID,
 			Stderr:     reason,
@@ -195,7 +195,7 @@ type ptyPlaceholder struct{}
 func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 	if !validID(msg.SessionID) {
 		log.Printf("Rejecting pty_open with invalid session_id %q", msg.SessionID)
-		sender.Send(protocol.PtyClosedMessage{
+		_ = sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "invalid session_id",
@@ -206,7 +206,7 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 	// Replay gate: same rationale as HandleExec.
 	if m.ptyReplay.Seen(msg.SessionID) {
 		log.Printf("Rejecting replayed pty_open session_id=%q", msg.SessionID)
-		sender.Send(protocol.PtyClosedMessage{
+		_ = sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "replayed session_id",
@@ -220,7 +220,7 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 		defer func() { <-m.ptySem }()
 	default:
 		log.Printf("Rejecting pty_open session_id=%q: agent at pty capacity", msg.SessionID)
-		sender.Send(protocol.PtyClosedMessage{
+		_ = sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "agent at pty capacity",
@@ -233,7 +233,7 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 	placeholder := ptyPlaceholder{}
 	if _, loaded := m.ptySessions.LoadOrStore(msg.SessionID, placeholder); loaded {
 		log.Printf("Rejecting pty_open session_id=%q: duplicate", msg.SessionID)
-		sender.Send(protocol.PtyClosedMessage{
+		_ = sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    "duplicate session_id",
@@ -254,7 +254,7 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 		log.Printf("Failed to open PTY session_id=%q: %v", msg.SessionID, err)
 		// Drop the placeholder we reserved.
 		m.ptySessions.CompareAndDelete(msg.SessionID, placeholder)
-		sender.Send(protocol.PtyClosedMessage{
+		_ = sender.Send(protocol.PtyClosedMessage{
 			Type:      "pty_closed",
 			SessionID: msg.SessionID,
 			Reason:    err.Error(),
@@ -289,7 +289,7 @@ func (m *Manager) HandlePtyOpen(msg *protocol.PtyOpenMessage, sender Sender) {
 		log.Printf("PTY close error for session_id=%q: %v", msg.SessionID, err)
 	}
 
-	sender.Send(protocol.PtyClosedMessage{
+	_ = sender.Send(protocol.PtyClosedMessage{
 		Type:      "pty_closed",
 		SessionID: msg.SessionID,
 		Reason:    "session ended",

--- a/internal/session/replay.go
+++ b/internal/session/replay.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"sync"
+	"time"
+)
+
+// Tracker remembers IDs seen within a sliding window so a captured
+// exec/pty message cannot be replayed against the agent. It is bounded
+// in both size (cap) and age (ttl): an ID falls out as soon as either
+// limit is reached. Safe for concurrent use.
+//
+// We don't persist the seen-set across process restarts; a restart
+// re-opens the replay window for at most ttl. This is acceptable
+// because (a) the host_id changes if the state dir is wiped and
+// (b) the backend can refuse stale messages once message-signing
+// (#9) lands.
+type Tracker struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+	cap  int
+	ttl  time.Duration
+	now  func() time.Time // injectable for tests
+}
+
+// NewTracker constructs a Tracker with the given capacity and time-to-live.
+func NewTracker(cap int, ttl time.Duration) *Tracker {
+	return &Tracker{
+		seen: make(map[string]time.Time, cap),
+		cap:  cap,
+		ttl:  ttl,
+		now:  time.Now,
+	}
+}
+
+// Seen records id and reports whether it was already known within ttl.
+// A return of true means "this is a replay; reject it".
+func (t *Tracker) Seen(id string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	cutoff := now.Add(-t.ttl)
+
+	// Lazy GC: drop anything older than cutoff.
+	for k, ts := range t.seen {
+		if ts.Before(cutoff) {
+			delete(t.seen, k)
+		}
+	}
+
+	if _, dup := t.seen[id]; dup {
+		return true
+	}
+
+	// Evict the oldest if we're at capacity.
+	if len(t.seen) >= t.cap {
+		var oldestKey string
+		var oldestTs time.Time
+		first := true
+		for k, ts := range t.seen {
+			if first || ts.Before(oldestTs) {
+				oldestKey, oldestTs, first = k, ts, false
+			}
+		}
+		delete(t.seen, oldestKey)
+	}
+
+	t.seen[id] = now
+	return false
+}

--- a/internal/session/replay_test.go
+++ b/internal/session/replay_test.go
@@ -1,0 +1,63 @@
+package session
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTrackerRejectsDuplicates(t *testing.T) {
+	t.Parallel()
+	tr := NewTracker(8, time.Minute)
+	if tr.Seen("a") {
+		t.Errorf("first call should not be a duplicate")
+	}
+	if !tr.Seen("a") {
+		t.Errorf("second call with same id should be a duplicate")
+	}
+}
+
+func TestTrackerExpiresOnTTL(t *testing.T) {
+	t.Parallel()
+	tr := NewTracker(8, 100*time.Millisecond)
+	now := time.Now()
+	tr.now = func() time.Time { return now }
+
+	if tr.Seen("a") {
+		t.Fatalf("first call duplicate?")
+	}
+	// Advance past TTL.
+	now = now.Add(200 * time.Millisecond)
+	if tr.Seen("a") {
+		t.Errorf("expired id should not count as replay")
+	}
+}
+
+func TestTrackerEvictsAtCapacity(t *testing.T) {
+	t.Parallel()
+	tr := NewTracker(2, time.Minute)
+	tr.Seen("a")
+	tr.Seen("b")
+	tr.Seen("c") // should evict "a"
+	if tr.Seen("a") {
+		t.Errorf("a should have been evicted; replay check fired anyway")
+	}
+}
+
+func TestTrackerConcurrent(t *testing.T) {
+	t.Parallel()
+	tr := NewTracker(1024, time.Minute)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := "id-" + strconv.Itoa(i)
+			if tr.Seen(id) {
+				t.Errorf("unexpected duplicate for %s", id)
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Final batch — closes the last four open issues and bumps to **v0.2.0**:

- **#20** — README least-privilege guidance + `--require-non-root` flag.
  - New systemd unit uses a dedicated `arktis` user, `ProtectSystem=strict`, `NoNewPrivileges=true`, and a scoped sudoers fragment for the elevation case.
  - Windows guidance recommends a managed service account / gMSA over `SYSTEM`.
  - `--require-non-root` (env: `ARKTIS_REQUIRE_NON_ROOT`) makes the agent fail fast if running as root.
  - Startup warning when running as root without `--allow-elevation`.
  - README "Security Model" section + Configuration table refreshed.
- **#15** — replay protection. Bounded (1024 entries, 10-minute TTL) `Tracker` rejects duplicate `request_id` (`exec_result exit_code=409`) and `session_id` (`pty_closed reason="replayed session_id"`) within the window. In-memory only for now; persistence across restart is future work.
- **#31** — DNS-rebinding mitigation. Agent persists the resolved peer IP on first connect; on reconnect, an IP change logs a warning and (with `--strict-endpoint` / `ARKTIS_STRICT_ENDPOINT`) refuses to proceed. State carries a new `last_backend_ip` field.
- **#9** — TLS pinning. `--ca-cert` (env: `ARKTIS_CA_CERT`) replaces the system trust pool with a single PEM file. `--pin-spki` (env: `ARKTIS_PIN_SPKI`) pins the leaf cert's `SubjectPublicKeyInfo` SHA-256; mismatches fail the dial via `VerifyPeerCertificate`. Both are independent defences-in-depth; either or both can be set. Tests cover SPKI hash stability and key-distinguishing behaviour. Per-message Ed25519 signing (the other half of #9) is left as future work.

Bumps Makefile `VERSION` from `0.1.0` to `0.2.0` to match the substantial security-feature delta since the previous release. After merge, tag `v0.2.0` to trigger the release workflow.

## Test plan

- [x] `go build ./...` clean on `linux`
- [x] `go vet ./...` clean on `linux`
- [x] `GOOS=windows go build ./...` clean
- [x] `GOOS=windows go vet ./...` clean
- [x] `go test -race ./...` passes (audit, executor, session, connection)
- [x] `gofmt -l` clean on touched files
- [ ] Manual: send same `request_id` twice; second returns `exit_code=409`
- [ ] Manual: with `--strict-endpoint`, force a DNS swap; agent refuses to reconnect
- [ ] Manual: with `--pin-spki <wrong-hash>`, dial fails with SPKI mismatch
- [ ] Manual: with `--require-non-root` and `User=root`, agent log.Fatals
- [ ] Manual: `make test` exits non-zero if a test fails (no longer a no-op)

https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz

---
_Generated by [Claude Code](https://claude.ai/code/session_013yJpb7bJPQXyfNi98BHkVz)_