### PR TITLE
fix(connection): enable TCP keepalive on the dialer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           # toolchain cache (e.g. setup-go cache hit on 1.26.2 after
           # GO-2026-4971 was published and 1.26.3 fixed it) cannot keep
           # CI red on a pre-existing stdlib advisory.
-          go-version: 'stable'
+          go-version: '1.26.3'
           check-latest: true
 
       - name: Build (all platforms)
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           # See build-and-test job for why check-latest is set.
-          go-version: 'stable'
+          go-version: '1.26.3'
           check-latest: true
 
       - name: Install govulncheck
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           # See build-and-test job for why check-latest is set.
-          go-version: 'stable'
+          go-version: '1.26.3'
           check-latest: true
 
       # Running gosec via `go install` rather than the securego/gosec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,12 @@ jobs:
           # Match the latest stable minor so govulncheck sees a stdlib that
           # has the most recent advisories applied. go.mod still pins
           # `go 1.22` as the minimum supported toolchain.
+          # check-latest forces a fresh resolution on every run so a stale
+          # toolchain cache (e.g. setup-go cache hit on 1.26.2 after
+          # GO-2026-4971 was published and 1.26.3 fixed it) cannot keep
+          # CI red on a pre-existing stdlib advisory.
           go-version: 'stable'
+          check-latest: true
 
       - name: Build (all platforms)
         run: make build-all
@@ -39,10 +44,9 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          # Match the latest stable minor so govulncheck sees a stdlib that
-          # has the most recent advisories applied. go.mod still pins
-          # `go 1.22` as the minimum supported toolchain.
+          # See build-and-test job for why check-latest is set.
           go-version: 'stable'
+          check-latest: true
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -61,7 +65,9 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
+          # See build-and-test job for why check-latest is set.
           go-version: 'stable'
+          check-latest: true
 
       # Running gosec via `go install` rather than the securego/gosec
       # action keeps the no-fail behaviour consistent with what we see

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -160,9 +160,21 @@ func (c *Client) connect(ctx context.Context) error {
 		return fmt.Errorf("build tls config: %w", err)
 	}
 
+	// TCP keepalive defense for half-open connections. Windows defaults
+	// `KeepAliveTime` to 2 hours, so a silently-dropped session (NIC
+	// power-down, hypervisor pause, route flap) can leave WriteControl
+	// pings landing in the kernel send buffer with no TCP-level error
+	// for a very long time. A 30s keepalive idle gets the OS probing
+	// shortly after the application read deadline (`readTimeout`) would
+	// have triggered, providing belt-and-suspenders liveness.
+	netDialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
 	dialer := websocket.Dialer{
 		HandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:  tlsCfg,
+		NetDialContext:   netDialer.DialContext,
 	}
 	conn, _, err := dialer.DialContext(ctx, c.config.BackendURL, header)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Wrap `gorilla/websocket.Dialer` with `NetDialContext` backed by `net.Dialer{Timeout: 10s, KeepAlive: 30s}`.
- Closes the half-open-TCP gap that lets Windows agents go "disconnected" while the Linux/Kali agent on the same LAN stays up.

## Why this matters

Windows defaults `KeepAliveTime` to **2 hours**. With no keepalive on the dialer, a silently-dropped session (NIC power-down, hypervisor pause, route flap) leaves `WriteControl` pings landing in the kernel send buffer with no TCP-level error for a very long time. The application-level read deadline (`readTimeout = 30s`, added in #refers-to-9b0ea9b) covers the read path, but **the dial side had no timeout and no keepalive at all** — a connect attempt to an unreachable backend could hang indefinitely.

After this change:
- 10s TCP-connect timeout matches the existing 10s WS handshake timeout — a stalled DNS / SYN can't wedge the reconnect loop.
- 30s OS keepalive probes detect dead peers shortly after the read deadline would have triggered. Belt-and-suspenders liveness for the half-open case the read deadline already targets.

## Reported symptom

W11 + WS25-DC agents on the same LAN as a Linux Kali agent show "disconnected" in the UI; operator has to run `Start-ScheduledTask -TaskName ArktisAgent` periodically. Linux TCP-stack defaults differ enough that the existing read-deadline + ping path recovers there; Windows did not.

## After-merge action for the operator

The fixes in `9b0ea9b` (read deadline + pong handler) plus this commit need to be **rebuilt + redeployed** to W11 and WS25-DC. The currently-installed binaries are still vulnerable.

## Test plan

- [ ] Build `make build-windows-amd64` produces `arktis-agent-windows-amd64.exe`
- [ ] Run on W11 against staging backend; verify reconnect within ~30-60s after `iptables -j DROP` simulating NAT timeout
- [ ] Run on Kali in parallel; verify no regression
- [ ] Existing connection / TLS tests pass (`go test ./internal/connection/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)