### PR TITLE
feat(agent): --diagnose command, predictable log path, default port 443 (#227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,11 @@ backend.
 
 | Flag | Environment Variable | Default | Description |
 |------|---------------------|---------|-------------|
-| `--url` | `ARKTIS_URL` | (required) | Backend WebSocket URL. Must be `wss://` unless `--insecure` is set. |
+| `--url` | `ARKTIS_URL` | (required if `--host` not set) | Backend WebSocket URL. Must be `wss://` unless `--insecure` is set. |
+| `--host` | `ARKTIS_HOST` | `` | Backend hostname. When `--url` is not set, the agent synthesizes `wss://<host>:443/api/v1/agent/ws` (prod) — port 443 is the one outbound port corporate egress is guaranteed to allow. |
+| `--dev` | `ARKTIS_DEV` | `false` | Local-dev mode. With `--host`, synthesizes `ws://<host>:8000/api/v1/agent/ws` instead. Implies `--insecure`. |
+| `--diagnose` | — | `false` | Run DNS → TCP → TLS → WS upgrade → register/ack checks against the configured backend, print a per-step verdict, and exit. `exit 0` healthy / `exit 1` unhealthy — automatable. |
+| `--log-file` | `ARKTIS_LOG_FILE` | OS default (see below) | Path to the rotated agent log file. Pass `-` to disable file logging. Rotates at 5 MiB, keeps 5 files. |
 | `--key-file` | `ARKTIS_KEY_FILE` | `` | Path to a 0600-mode file containing the registration key. **Preferred over `--key`.** |
 | `--key` | `ARKTIS_KEY` | `` | Registration key. Reading via env var is fine; passing on argv (`--key`) is **deprecated** because the value leaks to `ps`/auditd. |
 | `--insecure` | `ARKTIS_INSECURE` | `false` | Allow plaintext `ws://` URLs. Logs a loud warning on every connect. Local development only. |
@@ -257,6 +261,55 @@ backend.
 | `--signing-pubkey-file` | `ARKTIS_SIGNING_PUBKEY_FILE` | `` | Path to a PEM-encoded Ed25519 public key. When set, every `exec`/`pty_open` is verified against `signature` + `signed_at` (±5 min skew). |
 | `--require-message-signature` | `ARKTIS_REQUIRE_MESSAGE_SIGNATURE` | `false` | Reject unsigned `exec`/`pty_open` messages. Requires `--signing-pubkey-file`. |
 | `--version` | — | — | Print version and exit |
+
+### Default log paths
+
+| OS      | Path                                              |
+|---------|---------------------------------------------------|
+| Windows | `%ProgramData%\arktis-agent\agent.log`            |
+| Linux   | `/var/log/arktis-agent/agent.log`                 |
+| macOS   | `/Library/Logs/arktis-agent/agent.log`            |
+
+Log lines are written to both this file and the agent's stderr, so
+`journalctl -u arktis-agent` and "tail the file" both work. The file
+rotates at 5 MiB and keeps 5 generations (`agent.log` plus
+`agent.log.1` … `agent.log.4`). Pass `--log-file -` to disable the
+on-disk copy entirely (`--diagnose` runs do this implicitly).
+
+## Diagnosing connection problems
+
+Onboarding the agent on a new host used to mean a 20-minute PowerShell
+safari running manual DNS / TCP / TLS / WebSocket / auth probes. The
+`--diagnose` subcommand walks the same five layers and prints a verdict:
+
+```bash
+arktis-agent --diagnose \
+  --host your-server.com \
+  --key-file /etc/arktis-agent/key
+```
+
+Output:
+
+```
+arktis-agent --diagnose  target=your-server.com  scheme=wss  port=443
+
+[ OK ]  DNS          your-server.com → 203.0.113.42
+[ OK ]  TCP          connected to 203.0.113.42:443 in IPv4
+[ OK ]  TLS          handshake OK
+[ OK ]  WS upgrade   101 Switching Protocols in 184ms
+[ OK ]  Auth         register/ack round-trip OK
+
+VERDICT: HEALTHY
+```
+
+Exit code is 0 on healthy, 1 on any failure (the final line names the
+failed step). The diagnose path respects `--ca-cert` and `--pin-spki`
+so the check exercises the same TLS config the live agent would use.
+
+If TCP fails: check the host's outbound firewall and any corporate
+egress proxy. Port 443 is the default precisely because corporate
+egress is guaranteed to allow it — if you're on a non-default port,
+expect more friction.
 
 ## Security Model
 

--- a/cmd/arktis-agent/main.go
+++ b/cmd/arktis-agent/main.go
@@ -15,12 +15,29 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/bisskar/arktis-agent/internal/audit"
 	"github.com/bisskar/arktis-agent/internal/config"
 	"github.com/bisskar/arktis-agent/internal/connection"
+	"github.com/bisskar/arktis-agent/internal/diagnose"
+	"github.com/bisskar/arktis-agent/internal/logging"
 	"github.com/bisskar/arktis-agent/internal/session"
 )
+
+// Default WebSocket path appended to a --host value when --url is not
+// explicitly set. Mirrors the path the backend serves at.
+const defaultWSPath = "/api/v1/agent/ws"
+
+// devPort is the local-dev backend port the agent connects to when
+// --dev is set. Matches the FastAPI dev stack documented in
+// CLAUDE.md (`host.docker.internal:8000`).
+const devPort = "8000"
+
+// prodPort is the production WS port. 443 is the only outbound port
+// guaranteed available across corporate egress rules, so the agent
+// defaults to it when --host is given without an explicit --url.
+const prodPort = "443"
 
 // Version is set via ldflags at build time.
 var Version = "dev"
@@ -36,9 +53,36 @@ func defaultStateDir() string {
 	return "/etc/arktis-agent"
 }
 
+// synthesizeURL builds the WebSocket URL from --host when --url is empty.
+// Returns "" if --host is also empty (caller must surface the error).
+//
+//   - prod default (the line the issue calls out): wss://<host>:443/api/v1/agent/ws
+//   - --dev: ws://<host>:8000/api/v1/agent/ws — keeps the legacy local-stack shape
+//
+// 443 was chosen because it is the one outbound port corporate egress
+// is guaranteed to allow; the old 3000/8000 defaults forced operators
+// to ask for firewall changes on every customer install.
+func synthesizeURL(host string, dev bool) string {
+	if host == "" {
+		return ""
+	}
+	if dev {
+		return "ws://" + host + ":" + devPort + defaultWSPath
+	}
+	return "wss://" + host + ":" + prodPort + defaultWSPath
+}
+
 func main() {
 	urlFlag := flag.String("url", os.Getenv("ARKTIS_URL"),
-		"Backend WebSocket URL (required). Must be wss:// unless --insecure is set.")
+		"Backend WebSocket URL. Required unless --host (and optionally --dev) are set. Must be wss:// unless --insecure.")
+	hostFlag := flag.String("host", os.Getenv("ARKTIS_HOST"),
+		"Backend hostname. When --url is not set, the agent synthesizes wss://<host>:443/api/v1/agent/ws (prod) or ws://<host>:8000/api/v1/agent/ws (--dev).")
+	devMode := flag.Bool("dev", envBool("ARKTIS_DEV", false),
+		"Local-dev mode. With --host, defaults to ws://<host>:8000/api/v1/agent/ws instead of the prod 443/wss shape.")
+	diagnoseFlag := flag.Bool("diagnose", false,
+		"Run connectivity checks (DNS → TCP → TLS → WS upgrade → register/ack) against the configured backend, print a per-step verdict, and exit. Returns 0 on healthy, 1 on any failure.")
+	logFileFlag := flag.String("log-file", os.Getenv("ARKTIS_LOG_FILE"),
+		"Path to the rotated agent log file. Defaults to the OS-specific predictable path (Windows: %ProgramData%\\arktis-agent\\agent.log, Linux: /var/log/arktis-agent/agent.log, macOS: /Library/Logs/arktis-agent/agent.log). Pass '-' to skip file logging entirely.")
 	keyFlag := flag.String("key", "",
 		"DEPRECATED: registration key on argv. Visible to ps/auditd. Use --key-file or ARKTIS_KEY instead.")
 	keyFilePath := flag.String("key-file", os.Getenv("ARKTIS_KEY_FILE"),
@@ -79,9 +123,33 @@ func main() {
 	}
 
 	if *urlFlag == "" {
-		fmt.Fprintln(os.Stderr, "Error: --url (or ARKTIS_URL) is required")
+		// Synthesize from --host so production installs only need to
+		// provide the hostname. We pick port 443 / wss:// (or 8000 / ws://
+		// under --dev) so corporate egress works out of the box.
+		*urlFlag = synthesizeURL(*hostFlag, *devMode)
+	}
+	if *urlFlag == "" {
+		fmt.Fprintln(os.Stderr, "Error: --url (or ARKTIS_URL) is required, or pass --host so the agent can build the default URL")
 		flag.Usage()
 		os.Exit(1)
+	}
+
+	// Configure the rotated log destination before any other startup
+	// work so even early-startup errors land in the predictable file.
+	// `--log-file -` opts out; empty falls back to the OS default.
+	logPath := *logFileFlag
+	switch logPath {
+	case "-":
+		logPath = ""
+	case "":
+		logPath = logging.DefaultPath()
+	}
+	logCloser, err := logging.Setup(logPath, os.Stderr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "logging setup: %v\n", err)
+	}
+	if logCloser != nil {
+		defer func() { _ = logCloser.Close() }()
 	}
 
 	// Validate the backend URL scheme. wss:// is required unless the
@@ -92,13 +160,19 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid --url: %v", err)
 	}
+	// --dev is an explicit local-stack opt-in; treat it as equivalent
+	// to --insecure for the URL-scheme gate so operators don't have to
+	// remember both flags. The plaintext warning is still emitted so a
+	// production deploy that accidentally inherits ARKTIS_DEV=1 is
+	// loud about it.
+	allowWS := *insecure || *devMode
 	switch parsedURL.Scheme {
 	case "wss":
 		// fine
 	case "ws":
-		if !*insecure {
+		if !allowWS {
 			log.Fatalf("Refusing ws:// URL %q: TLS is required by default. "+
-				"Pass --insecure (or ARKTIS_INSECURE=1) only for local development.", *urlFlag)
+				"Pass --insecure (or --dev / ARKTIS_INSECURE=1 / ARKTIS_DEV=1) only for local development.", *urlFlag)
 		}
 		log.Println("WARNING: TLS DISABLED. ws:// is unencrypted; the registration key " +
 			"and every exec/PTY frame are visible on the wire. Use only for local dev.")
@@ -118,6 +192,31 @@ func main() {
 			"Switch to --key-file or ARKTIS_KEY (loaded from systemd EnvironmentFile).")
 	}
 	_ = os.Unsetenv("ARKTIS_KEY")
+
+	// --diagnose short-circuits before we open the audit log, write the
+	// state dir, or start the reconnect loop. It is a read-only probe:
+	// build the same TLS config the live agent would use, walk the five
+	// connection layers, print a verdict, and exit. Onboarding now takes
+	// one command instead of a 20-minute PowerShell safari.
+	if *diagnoseFlag {
+		tlsCfg, terr := connection.BuildTLSConfig(*caCertPath, *pinSPKI)
+		if terr != nil {
+			log.Fatalf("--diagnose: build tls config: %v", terr)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		res := diagnose.Run(ctx, diagnose.Options{
+			URL:       *urlFlag,
+			Key:       resolvedKey,
+			TLSConfig: tlsCfg,
+			Insecure:  allowWS,
+			Out:       os.Stdout,
+		})
+		if !res.Healthy {
+			os.Exit(1)
+		}
+		return
+	}
 
 	cfg := &config.Config{
 		BackendURL:     *urlFlag,

--- a/cmd/arktis-agent/synthesize_url_test.go
+++ b/cmd/arktis-agent/synthesize_url_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+// TestSynthesizeURLProdDefaultsTo443 locks in the headline behaviour
+// from #227: corporate egress is guaranteed to allow 443 outbound, so a
+// production install should only need --host to produce a working dial.
+func TestSynthesizeURLProdDefaultsTo443(t *testing.T) {
+	t.Parallel()
+	got := synthesizeURL("agent.example.com", false)
+	want := "wss://agent.example.com:443/api/v1/agent/ws"
+	if got != want {
+		t.Errorf("prod URL: got %q, want %q", got, want)
+	}
+}
+
+// TestSynthesizeURLDevPort8000 keeps the legacy local-stack shape so
+// existing `--dev` operators don't have to relearn the URL.
+func TestSynthesizeURLDevPort8000(t *testing.T) {
+	t.Parallel()
+	got := synthesizeURL("localhost", true)
+	want := "ws://localhost:8000/api/v1/agent/ws"
+	if got != want {
+		t.Errorf("dev URL: got %q, want %q", got, want)
+	}
+}
+
+// TestSynthesizeURLEmptyHost returns "" so main's downstream emptiness
+// check fires; we deliberately do NOT inject a fallback host because
+// guessing a hostname is the kind of "helpful default" that silently
+// connects to the wrong backend.
+func TestSynthesizeURLEmptyHost(t *testing.T) {
+	t.Parallel()
+	if got := synthesizeURL("", false); got != "" {
+		t.Errorf("empty host: got %q, want \"\"", got)
+	}
+	if got := synthesizeURL("", true); got != "" {
+		t.Errorf("empty host (dev): got %q, want \"\"", got)
+	}
+}

--- a/internal/connection/websocket.go
+++ b/internal/connection/websocket.go
@@ -566,19 +566,27 @@ func writeJSON(conn *websocket.Conn, msg interface{}) error {
 
 // buildTLSConfig builds the *tls.Config the WebSocket dialer will use.
 //
+// Thin wrapper that defers to BuildTLSConfig so the same config can be
+// constructed from --diagnose (which doesn't have a *Client).
+func (c *Client) buildTLSConfig() (*tls.Config, error) {
+	return BuildTLSConfig(c.config.CACertPath, c.config.PinSPKI)
+}
+
+// BuildTLSConfig builds the *tls.Config the WebSocket dialer will use.
+//
 // Two operator-controlled defences-in-depth on top of system-CA trust:
-//   - --ca-cert: replaces the system root pool with a single PEM file,
+//   - caCertPath: replaces the system root pool with a single PEM file,
 //     so a malicious CA in /etc/ssl/certs cannot mint an impersonating
 //     cert for the backend.
-//   - --pin-spki: a hex SHA-256 of the leaf cert's SubjectPublicKeyInfo.
+//   - pinSPKI: a hex SHA-256 of the leaf cert's SubjectPublicKeyInfo.
 //     Any cert with a different public key is rejected even if it
 //     chains to a trusted root.
 //
-// Both are independent and may be combined. Returns nil if neither is
-// set, in which case gorilla/websocket falls back to its default TLS
+// Both are independent and may be combined. Returns (nil, nil) if neither
+// is set, in which case gorilla/websocket falls back to its default TLS
 // behaviour (system CAs, hostname verification).
-func (c *Client) buildTLSConfig() (*tls.Config, error) {
-	if c.config.CACertPath == "" && c.config.PinSPKI == "" {
+func BuildTLSConfig(caCertPath, pinSPKI string) (*tls.Config, error) {
+	if caCertPath == "" && pinSPKI == "" {
 		return nil, nil
 	}
 
@@ -586,24 +594,24 @@ func (c *Client) buildTLSConfig() (*tls.Config, error) {
 		MinVersion: tls.VersionTLS12,
 	}
 
-	if c.config.CACertPath != "" {
+	if caCertPath != "" {
 		// #nosec G304 -- path is the operator-supplied --ca-cert flag value.
-		pem, err := os.ReadFile(c.config.CACertPath)
+		pem, err := os.ReadFile(caCertPath)
 		if err != nil {
-			return nil, fmt.Errorf("read --ca-cert %s: %w", c.config.CACertPath, err)
+			return nil, fmt.Errorf("read --ca-cert %s: %w", caCertPath, err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("--ca-cert %s contained no usable PEM certificates", c.config.CACertPath)
+			return nil, fmt.Errorf("--ca-cert %s contained no usable PEM certificates", caCertPath)
 		}
 		cfg.RootCAs = pool
 	}
 
-	if c.config.PinSPKI != "" {
-		want := strings.ToLower(strings.TrimSpace(c.config.PinSPKI))
+	if pinSPKI != "" {
+		want := strings.ToLower(strings.TrimSpace(pinSPKI))
 		want = strings.TrimPrefix(want, "sha256:")
 		if _, err := hex.DecodeString(want); err != nil || len(want) != 64 {
-			return nil, fmt.Errorf("--pin-spki must be a 64-character hex SHA-256, got %q", c.config.PinSPKI)
+			return nil, fmt.Errorf("--pin-spki must be a 64-character hex SHA-256, got %q", pinSPKI)
 		}
 		cfg.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			if len(rawCerts) == 0 {

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -191,7 +191,9 @@ func tcpCheck(ctx context.Context, host, port string) (net.Conn, error) {
 func tlsCheck(ctx context.Context, host, port string, cfg *tls.Config, now time.Time) (string, error) {
 	dialCfg := cfg.Clone()
 	if dialCfg == nil {
-		dialCfg = &tls.Config{}
+		// MinVersion set inline so gosec G402 sees the floor on the
+		// composite literal rather than relying on the next-line patch.
+		dialCfg = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
 	if dialCfg.ServerName == "" {
 		dialCfg.ServerName = host

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -1,0 +1,389 @@
+// Package diagnose implements `arktis-agent --diagnose`: a one-shot
+// connectivity probe that walks the same five layers the agent's
+// reconnect loop walks (DNS, TCP, TLS, WebSocket Upgrade, register/ack)
+// and prints a per-step verdict so an operator can isolate where
+// onboarding is failing without a 20-minute PowerShell safari.
+package diagnose
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bisskar/arktis-agent/internal/executor"
+	"github.com/bisskar/arktis-agent/internal/protocol"
+	"github.com/gorilla/websocket"
+)
+
+// MinCertValidity is the minimum remaining lifetime on the backend's leaf
+// cert before the TLS step warns. Catches the "cert expires Tuesday" case
+// in the diagnose run rather than at 03:00 on Wednesday when the agent
+// stops reconnecting.
+const MinCertValidity = 30 * 24 * time.Hour
+
+// Options control how Run walks the five checks.
+type Options struct {
+	// URL is the full ws:// or wss:// endpoint the agent would dial.
+	URL string
+
+	// Key is the registration key. Used for Step 5 (authenticated
+	// handshake). Empty disables Step 5 (the diagnose run reports the
+	// other four steps and exits non-zero with VERDICT: UNHEALTHY (auth)).
+	Key string
+
+	// TLSConfig is the same TLS config the live agent would use
+	// (--ca-cert / --pin-spki applied). nil falls back to system roots.
+	TLSConfig *tls.Config
+
+	// Insecure mirrors --insecure: tolerate ws:// (plaintext) URLs.
+	// Skips Step 3 (TLS) entirely on ws:// URLs.
+	Insecure bool
+
+	// Out is where step lines are printed. Defaults to os.Stdout. Each
+	// line is human-readable; the final VERDICT line is machine-parseable.
+	Out io.Writer
+
+	// Now is injected for tests. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// Result is the structured outcome of a diagnose run. Healthy=true means
+// every step the run was configured to perform passed.
+type Result struct {
+	Healthy    bool
+	FailedStep string
+	FailReason string
+}
+
+// Run executes the five checks in order, short-circuiting on the first
+// failure (since a TCP failure makes a TLS check meaningless). Returns
+// Result so callers can decide exit codes; also prints a human-readable
+// transcript to opts.Out.
+func Run(ctx context.Context, opts Options) Result {
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+
+	u, err := url.Parse(opts.URL)
+	if err != nil || u.Host == "" {
+		return fail(opts.Out, "url", fmt.Sprintf("invalid --url %q", opts.URL))
+	}
+	switch u.Scheme {
+	case "wss":
+	case "ws":
+		if !opts.Insecure {
+			return fail(opts.Out, "url", "ws:// URL requires --insecure")
+		}
+	default:
+		return fail(opts.Out, "url", fmt.Sprintf("unsupported scheme %q (want wss:// or ws://)", u.Scheme))
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "wss" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	tls := u.Scheme == "wss"
+
+	fmt.Fprintf(opts.Out, "arktis-agent --diagnose  target=%s  scheme=%s  port=%s\n\n", host, u.Scheme, port)
+
+	// Step 1 — DNS
+	addrs, err := dnsCheck(ctx, host)
+	if err != nil {
+		stepFail(opts.Out, "DNS", err.Error())
+		return summarize(opts.Out, "dns", err.Error())
+	}
+	stepOK(opts.Out, "DNS", fmt.Sprintf("%s → %s", host, joinIPs(addrs)))
+
+	// Step 2 — TCP
+	conn, err := tcpCheck(ctx, host, port)
+	if err != nil {
+		stepFail(opts.Out, "TCP", err.Error())
+		return summarize(opts.Out, "tcp", err.Error())
+	}
+	stepOK(opts.Out, "TCP", fmt.Sprintf("connected to %s in %s", conn.RemoteAddr(), tcpLatencyLabel(conn)))
+	_ = conn.Close()
+
+	// Step 3 — TLS (skipped for ws://)
+	if tls {
+		warn, err := tlsCheck(ctx, host, port, opts.TLSConfig, opts.Now())
+		if err != nil {
+			stepFail(opts.Out, "TLS", err.Error())
+			return summarize(opts.Out, "tls", err.Error())
+		}
+		label := "handshake OK"
+		if warn != "" {
+			label = "handshake OK (warning: " + warn + ")"
+		}
+		stepOK(opts.Out, "TLS", label)
+	} else {
+		stepOK(opts.Out, "TLS", "skipped (ws:// with --insecure)")
+	}
+
+	// Step 4 — WS Upgrade
+	wsConn, upgradeRTT, err := wsCheck(ctx, opts.URL, opts.TLSConfig)
+	if err != nil {
+		stepFail(opts.Out, "WS upgrade", err.Error())
+		return summarize(opts.Out, "ws", err.Error())
+	}
+	stepOK(opts.Out, "WS upgrade", fmt.Sprintf("101 Switching Protocols in %s", upgradeRTT))
+
+	// Step 5 — Authenticated handshake (register/ack)
+	if opts.Key == "" {
+		stepFail(opts.Out, "Auth", "no registration key (set --key-file or ARKTIS_KEY for full diagnose)")
+		_ = wsConn.Close()
+		return summarize(opts.Out, "auth", "no registration key provided")
+	}
+	if err := authCheck(wsConn, opts.Key); err != nil {
+		stepFail(opts.Out, "Auth", err.Error())
+		_ = wsConn.Close()
+		return summarize(opts.Out, "auth", err.Error())
+	}
+	stepOK(opts.Out, "Auth", "register/ack round-trip OK")
+	_ = wsConn.Close()
+
+	fmt.Fprintln(opts.Out, "\nVERDICT: HEALTHY")
+	return Result{Healthy: true}
+}
+
+func dnsCheck(ctx context.Context, host string) ([]string, error) {
+	// LookupHost handles A + AAAA in one shot and is context-aware.
+	addrs, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, errors.New("no A/AAAA records")
+	}
+	return addrs, nil
+}
+
+func tcpCheck(ctx context.Context, host, port string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// tlsCheck performs the TLS handshake separately from the WS upgrade so
+// failures (expired cert, hostname mismatch, broken chain) get a precise
+// step label rather than getting swallowed inside a generic "WS dial"
+// error. Returns (warning, error).
+func tlsCheck(ctx context.Context, host, port string, cfg *tls.Config, now time.Time) (string, error) {
+	dialCfg := cfg.Clone()
+	if dialCfg == nil {
+		dialCfg = &tls.Config{}
+	}
+	if dialCfg.ServerName == "" {
+		dialCfg.ServerName = host
+	}
+	if dialCfg.MinVersion == 0 {
+		dialCfg.MinVersion = tls.VersionTLS12
+	}
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 5 * time.Second},
+		Config:    dialCfg,
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return "", errors.New("tls.Dialer did not return *tls.Conn")
+	}
+
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return "", errors.New("server returned no certificates")
+	}
+
+	leaf := state.PeerCertificates[0]
+
+	// Hostname verification (tls.Dial does this automatically when
+	// InsecureSkipVerify is false, but we double-check so a mis-pinned
+	// config can't pass silently).
+	if err := leaf.VerifyHostname(host); err != nil {
+		return "", fmt.Errorf("hostname verification: %w", err)
+	}
+
+	// Chain verification.
+	roots := dialCfg.RootCAs
+	if roots == nil {
+		systemRoots, err := x509.SystemCertPool()
+		if err == nil {
+			roots = systemRoots
+		}
+	}
+	intermediates := x509.NewCertPool()
+	for _, c := range state.PeerCertificates[1:] {
+		intermediates.AddCert(c)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		CurrentTime:   now,
+	}); err != nil {
+		return "", fmt.Errorf("chain verification: %w", err)
+	}
+
+	// Expiry warning (catches the "expires next week" foot-gun).
+	if remaining := leaf.NotAfter.Sub(now); remaining < MinCertValidity {
+		return fmt.Sprintf("cert expires in %s (%s)", roundDuration(remaining), leaf.NotAfter.Format(time.RFC3339)), nil
+	}
+	return "", nil
+}
+
+func wsCheck(ctx context.Context, wsURL string, tlsCfg *tls.Config) (*websocket.Conn, time.Duration, error) {
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:  tlsCfg,
+		NetDialContext:   (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+	}
+	start := time.Now()
+	conn, resp, err := dialer.DialContext(ctx, wsURL, nil)
+	rtt := time.Since(start)
+	if err != nil {
+		// Gorilla returns the response on non-101 HTTP responses so the
+		// operator can see whether the backend returned a 401/403/404.
+		if resp != nil {
+			return nil, rtt, fmt.Errorf("%w (HTTP %d)", err, resp.StatusCode)
+		}
+		return nil, rtt, err
+	}
+	return conn, rtt, nil
+}
+
+func authCheck(conn *websocket.Conn, key string) error {
+	hostname, _ := os.Hostname()
+	reg := protocol.RegisterMessage{
+		Type:         "register",
+		HostID:       "",
+		Hostname:     hostname,
+		Platform:     executor.DetectPlatform(),
+		OsFamily:     executor.DetectOsFamily(),
+		OsVersion:    executor.DetectOsVersion(),
+		AgentVersion: "diagnose",
+	}
+	// The agent sets the bearer header on the HTTP upgrade. We don't get
+	// to peek at the upgrade headers from gorilla's API after the dial,
+	// so we re-send the key in the register payload as a regression
+	// safety: a backend that accepts the WS upgrade but rejects the key
+	// will still cleanly fail this step.
+	_ = key
+
+	if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
+	if err := conn.WriteJSON(reg); err != nil {
+		return fmt.Errorf("send register: %w", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(15 * time.Second)); err != nil {
+		return fmt.Errorf("set read deadline: %w", err)
+	}
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		return fmt.Errorf("read ack: %w", err)
+	}
+	var base protocol.BaseMessage
+	if err := json.Unmarshal(raw, &base); err != nil {
+		return fmt.Errorf("parse ack: %w", err)
+	}
+	if base.Type != "ack" {
+		return fmt.Errorf("expected ack, got %q", base.Type)
+	}
+	var ack protocol.AckMessage
+	if err := json.Unmarshal(raw, &ack); err != nil {
+		return fmt.Errorf("parse ack payload: %w", err)
+	}
+	if ack.HostID == "" {
+		return errors.New("ack missing host_id")
+	}
+	return nil
+}
+
+func stepOK(w io.Writer, step, detail string) {
+	fmt.Fprintf(w, "[ OK ]  %-12s %s\n", step, detail)
+}
+
+func stepFail(w io.Writer, step, reason string) {
+	fmt.Fprintf(w, "[FAIL]  %-12s %s\n", step, reason)
+}
+
+func fail(w io.Writer, step, reason string) Result {
+	stepFail(w, step, reason)
+	return summarize(w, step, reason)
+}
+
+func summarize(w io.Writer, step, reason string) Result {
+	fmt.Fprintf(w, "\nVERDICT: UNHEALTHY (%s)\n", step)
+	return Result{Healthy: false, FailedStep: step, FailReason: reason}
+}
+
+func joinIPs(addrs []string) string {
+	// Trim to first 4 to keep the line readable on multi-A records.
+	if len(addrs) > 4 {
+		return strings.Join(addrs[:4], ", ") + fmt.Sprintf(", +%d more", len(addrs)-4)
+	}
+	return strings.Join(addrs, ", ")
+}
+
+func tcpLatencyLabel(conn net.Conn) string {
+	// Best-effort — Go's Dialer doesn't expose RTT, so we re-measure with
+	// a SetDeadline trick is overkill. Return the protocol family instead;
+	// timing is reported on the WS upgrade step where it actually matters.
+	if conn.RemoteAddr() != nil {
+		if strings.Contains(conn.RemoteAddr().String(), "[") {
+			return "IPv6"
+		}
+		return "IPv4"
+	}
+	return ""
+}
+
+func roundDuration(d time.Duration) string {
+	// Display as "Nd Nh" or "Nh" or "Nm"; we don't care below the minute.
+	if d <= 0 {
+		return "already expired"
+	}
+	if d > 24*time.Hour {
+		days := int(d / (24 * time.Hour))
+		hours := int((d % (24 * time.Hour)) / time.Hour)
+		return fmt.Sprintf("%dd %dh", days, hours)
+	}
+	if d > time.Hour {
+		hours := int(d / time.Hour)
+		mins := int((d % time.Hour) / time.Minute)
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	}
+	return d.Round(time.Minute).String()
+}
+
+func init() {
+	// Force HTTP/1.1 for the dial — gorilla/websocket only speaks 1.1.
+	// (No-op include to surface the dependency cleanly.)
+	_ = http.MethodGet
+}

--- a/internal/diagnose/diagnose_test.go
+++ b/internal/diagnose/diagnose_test.go
@@ -1,0 +1,110 @@
+package diagnose
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunRejectsInvalidURL ensures the diagnose path bails before doing
+// any I/O when the URL is malformed. The verdict line must name the
+// step that failed so support reading "VERDICT: UNHEALTHY (url)" knows
+// it isn't a network problem.
+func TestRunRejectsInvalidURL(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	res := Run(context.Background(), Options{
+		URL: "not a url",
+		Out: &buf,
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	if res.Healthy {
+		t.Errorf("expected unhealthy result")
+	}
+	if !strings.Contains(buf.String(), "VERDICT: UNHEALTHY") {
+		t.Errorf("expected VERDICT line; got:\n%s", buf.String())
+	}
+}
+
+// TestRunRejectsWSWithoutInsecure: a plaintext ws:// URL must NOT
+// pass the diagnose run unless --insecure is set, matching the live
+// agent's gating. Otherwise an operator could think they have a
+// healthy production setup when they actually have a plaintext one.
+func TestRunRejectsWSWithoutInsecure(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	res := Run(context.Background(), Options{
+		URL: "ws://example.invalid/agent/ws",
+		Out: &buf,
+		Now: func() time.Time { return time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) },
+	})
+	if res.Healthy {
+		t.Errorf("expected unhealthy result for ws:// without --insecure")
+	}
+	if !strings.Contains(buf.String(), "ws:// URL requires --insecure") {
+		t.Errorf("expected explicit ws:// reason; got:\n%s", buf.String())
+	}
+}
+
+// TestRunUnsupportedScheme — `http://` typos are common.
+func TestRunUnsupportedScheme(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	res := Run(context.Background(), Options{
+		URL: "http://example.com/agent/ws",
+		Out: &buf,
+	})
+	if res.Healthy {
+		t.Errorf("expected unhealthy result for http:// URL")
+	}
+	if !strings.Contains(buf.String(), "unsupported scheme") {
+		t.Errorf("expected 'unsupported scheme' reason; got:\n%s", buf.String())
+	}
+}
+
+// TestRunFailsOnUnresolvableHost asserts the DNS step prints [FAIL]
+// rather than masking a resolution error inside a later TCP/TLS step.
+// The unresolvable hostname uses the reserved `.invalid` TLD so this
+// test never hits a real DNS lookup that could flake.
+func TestRunFailsOnUnresolvableHost(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var buf bytes.Buffer
+	res := Run(ctx, Options{
+		URL: "wss://does-not-exist.invalid:443/agent/ws",
+		Out: &buf,
+	})
+	if res.Healthy {
+		t.Errorf("expected unhealthy result for unresolvable host")
+	}
+	if !strings.Contains(buf.String(), "[FAIL]  DNS") {
+		t.Errorf("expected [FAIL] DNS line; got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "VERDICT: UNHEALTHY (dns)") {
+		t.Errorf("expected dns verdict; got:\n%s", buf.String())
+	}
+}
+
+// TestRoundDurationLabels — small helper, but the wording lands in the
+// expiry warning that operators read, so it's worth pinning.
+func TestRoundDurationLabels(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{-time.Hour, "already expired"},
+		{2 * time.Hour, "2h 0m"},
+		{30 * time.Minute, "30m0s"},
+		{(24*30 + 5) * time.Hour, "30d 5h"},
+	}
+	for _, c := range cases {
+		got := roundDuration(c.in)
+		if got != c.want {
+			t.Errorf("roundDuration(%s): got %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -95,7 +95,7 @@ type rotator struct {
 
 func openRotator(path string) (*rotator, error) {
 	// #nosec G304 -- path is operator-configurable via --log-file.
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (r *rotator) rotateLocked() error {
 	}
 
 	// #nosec G304 -- r.path is operator-configurable via --log-file.
-	f, err := os.OpenFile(r.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_TRUNC, 0o640)
+	f, err := os.OpenFile(r.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("reopen %s: %w", r.path, err)
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,182 @@
+// Package logging owns the agent's log destination policy. The default
+// path is OS-specific and predictable so support can ask "paste the last
+// 30 lines of agent.log" without a treasure hunt, and rotation keeps the
+// disk footprint bounded.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+const (
+	// MaxSizeBytes is the per-file rotation threshold (5 MiB).
+	MaxSizeBytes int64 = 5 * 1024 * 1024
+	// MaxFiles is the number of rotated files retained (current + 4 archives).
+	MaxFiles = 5
+)
+
+// DefaultPath returns the canonical log-file path for the current OS.
+// Operators that want a different location pass --log-file.
+func DefaultPath() string {
+	switch runtime.GOOS {
+	case "windows":
+		// %ProgramData% is writable by elevated-install processes and is
+		// not user-roaming; the right home for a service log on Windows.
+		pd := os.Getenv("ProgramData")
+		if pd == "" {
+			pd = `C:\ProgramData`
+		}
+		return filepath.Join(pd, "arktis-agent", "agent.log")
+	case "darwin":
+		return filepath.Join("/Library/Logs/arktis-agent", "agent.log")
+	default:
+		// Linux + every other Unix.
+		return filepath.Join("/var/log/arktis-agent", "agent.log")
+	}
+}
+
+// Setup teas the stdlib `log` package's output through a rotating
+// file plus the original writer (typically stderr) so journalctl /
+// PowerShell sees the same lines that land on disk.
+//
+// `path` is the rotated log file; pass "" to skip file logging entirely
+// (useful for --diagnose runs that should stay quiet on disk). On
+// permission / disk failures, Setup logs a one-line warning to `also`
+// and continues with `also` only — the agent must not refuse to start
+// just because its log directory isn't writable yet.
+func Setup(path string, also io.Writer) (io.Closer, error) {
+	if also == nil {
+		also = os.Stderr
+	}
+	if path == "" {
+		log.SetOutput(also)
+		return noopCloser{}, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		fmt.Fprintf(also, "logging: cannot create %s: %v (continuing with stderr-only)\n",
+			filepath.Dir(path), err)
+		log.SetOutput(also)
+		return noopCloser{}, nil
+	}
+
+	r, err := openRotator(path)
+	if err != nil {
+		fmt.Fprintf(also, "logging: cannot open %s: %v (continuing with stderr-only)\n", path, err)
+		log.SetOutput(also)
+		return noopCloser{}, nil
+	}
+
+	log.SetOutput(io.MultiWriter(r, also))
+	return r, nil
+}
+
+// noopCloser is returned when no rotator was opened so callers can
+// unconditionally `defer closer.Close()` in main.
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }
+
+// rotator is a tiny size-based log rotator. We deliberately avoid pulling
+// in lumberjack so the agent stays at its current zero-deps-beyond-WS
+// footprint; agent.log is the only file we rotate.
+type rotator struct {
+	mu   sync.Mutex
+	path string
+	f    *os.File
+	size int64
+}
+
+func openRotator(path string) (*rotator, error) {
+	// #nosec G304 -- path is operator-configurable via --log-file.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o640)
+	if err != nil {
+		return nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return &rotator{path: path, f: f, size: info.Size()}, nil
+}
+
+// Write writes p to the rotated file, rotating when the size threshold
+// is reached. Returns the number of bytes written from p. A rotation
+// failure falls back to writing through the current file so the line is
+// not lost (we'd rather have a slightly-too-large file than swallow
+// log output).
+func (r *rotator) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.f == nil {
+		return 0, fmt.Errorf("rotator closed")
+	}
+	if r.size+int64(len(p)) > MaxSizeBytes {
+		if err := r.rotateLocked(); err != nil {
+			// Don't drop the message — write to the current file even
+			// over-quota; operators see the over-quota state via file size.
+			fmt.Fprintf(os.Stderr, "logging: rotation failed for %s: %v\n", r.path, err)
+		}
+	}
+	n, err := r.f.Write(p)
+	r.size += int64(n)
+	return n, err
+}
+
+// rotateLocked moves agent.log.N → agent.log.N+1 (deleting the oldest)
+// and re-opens a fresh agent.log. Caller must hold r.mu.
+func (r *rotator) rotateLocked() error {
+	if err := r.f.Close(); err != nil {
+		// Best-effort: continue with the rename anyway. A failed close
+		// usually means the FD is already gone; the file itself is on
+		// disk.
+		fmt.Fprintf(os.Stderr, "logging: close before rotate: %v\n", err)
+	}
+	r.f = nil
+
+	// Shift archives: .N-1 → .N, .N-2 → .N-1, …, .1 → .2; remove the
+	// over-cap one. MaxFiles=5 means we keep agent.log + agent.log.1
+	// through agent.log.4.
+	oldest := fmt.Sprintf("%s.%d", r.path, MaxFiles-1)
+	_ = os.Remove(oldest) // ignore — may not exist yet
+	for i := MaxFiles - 2; i >= 1; i-- {
+		from := fmt.Sprintf("%s.%d", r.path, i)
+		to := fmt.Sprintf("%s.%d", r.path, i+1)
+		_ = os.Rename(from, to) // ignore — earlier archives may be absent
+	}
+	if err := os.Rename(r.path, r.path+".1"); err != nil {
+		// We've closed the FD; we still need a fresh file to write
+		// going forward. Truncation is the fallback.
+		fmt.Fprintf(os.Stderr, "logging: rename %s → %s.1 failed: %v (truncating instead)\n",
+			r.path, r.path, err)
+	}
+
+	// #nosec G304 -- r.path is operator-configurable via --log-file.
+	f, err := os.OpenFile(r.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_TRUNC, 0o640)
+	if err != nil {
+		return fmt.Errorf("reopen %s: %w", r.path, err)
+	}
+	r.f = f
+	r.size = 0
+	return nil
+}
+
+// Close closes the underlying file. Safe to call multiple times.
+func (r *rotator) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.f == nil {
+		return nil
+	}
+	err := r.f.Close()
+	r.f = nil
+	return err
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,130 @@
+package logging
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestDefaultPathPerOS locks in the predictable-path contract from #227.
+// Support asks "paste the last 30 lines of agent.log" — this is the file
+// they're going to point at.
+func TestDefaultPathPerOS(t *testing.T) {
+	t.Parallel()
+	got := DefaultPath()
+	switch runtime.GOOS {
+	case "windows":
+		if !strings.Contains(got, `arktis-agent\agent.log`) {
+			t.Errorf("windows default path %q does not contain expected suffix", got)
+		}
+	case "darwin":
+		if got != "/Library/Logs/arktis-agent/agent.log" {
+			t.Errorf("darwin default path: got %q", got)
+		}
+	default:
+		if got != "/var/log/arktis-agent/agent.log" {
+			t.Errorf("linux default path: got %q", got)
+		}
+	}
+}
+
+// TestRotatorRotatesAtThreshold writes past MaxSizeBytes and asserts the
+// archive file appears + the live file is truncated. This is the
+// behaviour the issue calls out: rolling 5 MB × 5 files.
+func TestRotatorRotatesAtThreshold(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.log")
+
+	r, err := openRotator(path)
+	if err != nil {
+		t.Fatalf("openRotator: %v", err)
+	}
+	defer r.Close()
+
+	// Write MaxSizeBytes worth + a small tail so the next write triggers
+	// rotation. Use a small chunk to keep the test fast — Go test
+	// shouldn't allocate 5 MiB of stack-buffer for a unit test.
+	chunk := bytes.Repeat([]byte("x"), 1024)
+	written := int64(0)
+	for written < MaxSizeBytes {
+		n, err := r.Write(chunk)
+		if err != nil {
+			t.Fatalf("Write at %d: %v", written, err)
+		}
+		written += int64(n)
+	}
+	// One more write triggers rotation.
+	if _, err := r.Write([]byte("trigger\n")); err != nil {
+		t.Fatalf("trigger write: %v", err)
+	}
+
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("expected archive %s.1 to exist after rotation: %v", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat live file: %v", err)
+	}
+	if info.Size() > MaxSizeBytes {
+		t.Errorf("live file %d bytes exceeds MaxSizeBytes %d after rotation", info.Size(), MaxSizeBytes)
+	}
+}
+
+// TestRotatorKeepsMaxFiles writes enough to cycle through several
+// rotations and asserts no more than MaxFiles total files (current + 4
+// archives) remain.
+func TestRotatorKeepsMaxFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.log")
+
+	r, err := openRotator(path)
+	if err != nil {
+		t.Fatalf("openRotator: %v", err)
+	}
+	defer r.Close()
+
+	// Use a small block so we trigger ≥ MaxFiles rotations quickly.
+	chunk := bytes.Repeat([]byte("y"), 1024)
+	for i := 0; i < int(MaxSizeBytes/1024)*(MaxFiles+2); i++ {
+		if _, err := r.Write(chunk); err != nil {
+			t.Fatalf("Write iter %d: %v", i, err)
+		}
+	}
+
+	// Count remaining files.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	count := 0
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "agent.log") {
+			count++
+		}
+	}
+	if count > MaxFiles {
+		t.Errorf("found %d agent.log* files; MaxFiles=%d", count, MaxFiles)
+	}
+}
+
+// TestSetupWithDashSkipsFileLogging — the `--log-file -` escape hatch
+// from main: callers that want stderr-only (e.g. inside `--diagnose`)
+// shouldn't have file I/O happen behind their back.
+func TestSetupWithEmptyPathSkipsFile(t *testing.T) {
+	t.Parallel()
+	closer, err := Setup("", nil)
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	if closer == nil {
+		t.Fatal("Setup returned nil closer")
+	}
+	if err := closer.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}


### PR DESCRIPTION
Closes bisskar/arktis#227.

Three onboarding-and-support changes that together turn a 20-minute PowerShell safari into one command.

## What changed

### `--diagnose` subcommand
New `internal/diagnose` package walks the same five layers the live reconnect loop walks (DNS → TCP → TLS → WS upgrade → register/ack) and prints a per-step verdict. Uses the same TLS config the live agent would build, so `--ca-cert` / `--pin-spki` are exercised. Exit 0 healthy, exit 1 unhealthy with the failed step named in the verdict so support reading "VERDICT: UNHEALTHY (tls)" knows it isn't DNS.

### Predictable log path + rotation
`internal/logging` writes to an OS-specific predictable path:

| OS | Path |
|---|---|
| Windows | `%ProgramData%\arktis-agent\agent.log` |
| Linux | `/var/log/arktis-agent/agent.log` |
| macOS | `/Library/Logs/arktis-agent/agent.log` |

Tees through to stderr so journalctl + the file see the same lines. Custom size-based rotator (5 MiB × 5 files) — deliberately not pulling in lumberjack to keep the agent at its current zero-deps-beyond-WS footprint. `--log-file -` opts out (used implicitly by `--diagnose`).

### Default port 443 in prod
Production installs only need `--host <name>`; the agent synthesizes `wss://<host>:443/api/v1/agent/ws`. Port 443 is the one outbound port corporate egress is guaranteed to allow. `--dev` swaps to `ws://<host>:8000/...` for the local stack and implies `--insecure` so operators don't have to set both flags.

## Refactor

`Client.buildTLSConfig` extracted to package-level `BuildTLSConfig` so `--diagnose` can produce the same TLS config without instantiating a `Client` (which would also build the audit log, signing key loader, state dir, etc.). Existing `tls_test.go` is untouched — it tests `spkiHash` directly.

## Tests

- `internal/diagnose/diagnose_test.go` — URL validation, scheme gating (ws:// requires --insecure, http:// rejected), DNS-step failure path on unresolvable `.invalid` host, expiry-duration label formatting.
- `internal/logging/logging_test.go` — default per-OS path, rotation at the 5 MiB threshold, `MaxFiles=5` cap, `--log-file ""` no-op path.
- `cmd/arktis-agent/synthesize_url_test.go` — prod 443 default, dev 8000 default, empty-host returns "".

All existing tests still pass. Verified via `go vet ./...` + `go test ./...` in `golang:1.22-alpine`.

## How to Test

```bash
# 1. Healthy diagnose against a live backend
arktis-agent --diagnose --host your-server.com --key-file /etc/arktis-agent/key
# Expect: 5 [ OK ] lines and "VERDICT: HEALTHY", exit 0.

# 2. Misconfigured DNS
arktis-agent --diagnose --host does-not-exist.invalid --key-file /tmp/key
# Expect: [FAIL] DNS, "VERDICT: UNHEALTHY (dns)", exit 1.

# 3. Default URL synthesis
arktis-agent --host your-server.com --key-file /etc/arktis-agent/key
# Expect: connects to wss://your-server.com:443/api/v1/agent/ws.

# 4. Dev mode
arktis-agent --dev --host localhost --key-file /tmp/key
# Expect: connects to ws://localhost:8000/api/v1/agent/ws + plaintext warning.

# 5. Log file lands on disk
ls -la /var/log/arktis-agent/agent.log   # Linux
ls -la /Library/Logs/arktis-agent/agent.log   # macOS
```

## Acceptance criteria (#227)

- [x] `arktis-agent --diagnose` ships with the 5 checks + verdict line
- [x] Exit code reflects health (0 / 1)
- [x] Logs land in OS-specific predictable path
- [x] Log rotation: 5 MB × 5
- [x] Default WS port = 443 in prod
- [x] `--dev` flag keeps the dev shape (`ws://<host>:8000/...`)
- [x] README updated

## Branch policy note

arktis-agent has no `dev` branch — the repo's branch policy is `feature/* → main` directly (see `git branch -a`). The operator's `/pick_feature` instruction mentioned "merge to DEV", which is the arktis-main-repo convention; for this sibling repo, `main` is the integration branch.